### PR TITLE
fix num param and attach names for intc-tl

### DIFF
--- a/lib/export-scala-base.js
+++ b/lib/export-scala-base.js
@@ -287,7 +287,7 @@ ${indent(6)(
 
 class N${comp.name}TopBase(c: N${
   comp.name
-}TopParams)(implicit p: Parameters) extends LazyModule
+}TopParams)(implicit p: Parameters) extends SimpleLazyModule
 {
   val imp = LazyModule(new L${comp.name}(c.blackbox))
   ${get(generators, 'channel.common.node', () => '')(comp)}

--- a/lib/intc-tl.js
+++ b/lib/intc-tl.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const masterAdapterGen = () => p => `IntSourceNode(IntSourcePortSimple(num = ${p.abstractionTypes[0].portMaps.length}))`;
+const masterAdapterGen = () => p => `IntSourceNode(IntSourcePortSimple(num = ${Object.keys(p.abstractionTypes[0].portMaps).length}))`;
 
 const masterBusParamsGen = () => p => `
 case class P${p.name}Params(burstBytes: Int)
@@ -9,7 +9,7 @@ case class P${p.name}Params(burstBytes: Int)
 const masterNodeGen = () => e => `
 val ${e.name}Node: IntSourceNode = imp.${e.name}Node`;
 
-const masterAttachGen = () => e => `bap.ibus := name.${e.name}Node`;
+const masterAttachGen = comp => e => `bap.ibus := ${comp.name}_top.${e.name}Node`;
 
 const fixme = () => `
 // FIXME`;


### PR DESCRIPTION
- change `N{component}Top` class to `SimpleLazyModule` so that the `module` field is defined.
- change the names in the attach code to match the declared component name
- fix the `num` parameter so that it does not generate `(num = undefined)`