### PR TITLE
make TL adapters optional, delete trailing whitespace

### DIFF
--- a/lib/apb-scala.js
+++ b/lib/apb-scala.js
@@ -48,12 +48,15 @@ case class P${e.name}Params(
 const slaveNodeGen = comp => e => {
   const portMaps = e.abstractionTypes.find(e => e.viewRef === 'RTLview').portMaps;
   const dataWidth = comp.model.ports.find(p => p.name === portMaps.PRDATA).wire.width;
-  return `val ${e.name}Node: TLInwardNode = (
-  imp.${e.name}Node
+  return `
+val ${e.name}Node: APBSlaveNode = imp.${e.name}Node
+
+def get${e.name}Node(): TLInwardNode = {(
+  ${e.name}Node
     := TLToAPB(false)
     := TLBuffer()
     := TLFragmenter((${dataWidth + ' / 8'}), c.blackbox.cacheBlockBytes, holdFirstDeny=true)
-)
+)}
 `;
 };
 

--- a/lib/axi4-tl.js
+++ b/lib/axi4-tl.js
@@ -41,7 +41,7 @@ const slaveAdapterGen = comp => e => {
     AXI4SlavePortParameters(
       slaves = Seq(
         AXI4SlaveParameters(
-          address       = List(AddressSet(${params}.base, 0x${(Math.pow(2, addrWidth) - 1).toString(16)}L)),
+          address       = List(AddressSet(${params}.base, ((1L << ${addrWidth}) - 1))),
           executable    = ${params}.executable,
           supportsWrite = TransferSizes${portMaps.WDATA ? `(1, (${maxTransferSize}))` : '.none'},
           supportsRead  = TransferSizes${portMaps.RDATA ? `(1, (${maxTransferSize}))` : '.none'},
@@ -90,8 +90,10 @@ const slaveNodeGen = comp => e => {
   const axi4BufferParams = `${params}.axi4BufferParams`;
   const tlBufferParams = `${params}.tlBufferParams`;
   return `
-val ${e.name}Node: TLInwardNode = (
-  imp.${e.name}Node
+val ${e.name}Node: AXI4SlaveNode = imp.${e.name}Node
+
+def get${e.name}NodeTLAdapter(): TLInwardNode = {(
+  ${e.name}Node
     := AXI4Buffer(
       aw = ${axi4BufferParams}.aw,
       ar = ${axi4BufferParams}.ar,
@@ -100,13 +102,12 @@ val ${e.name}Node: TLInwardNode = (
       b = ${axi4BufferParams}.b
     )
     := AXI4UserYanker(capMaxFlight = Some(${params}.maxTransactions))
-${e.busType.name === 'AXI4' ?`
-    := AXI4Deinterleaver(c.blackbox.cacheBlockBytes)
-    := AXI4IdIndexer(idBits = ${params}.maxFifoBits)` : '\n'
-}
-    := TLToAXI4()
-${e.busType.name === 'AXI4Lite' ? `
-    := TLFragmenter((${dataWidth + ' / 8'}), c.blackbox.cacheBlockBytes, holdFirstDeny=true)` : '\n'
+${e.busType.name === 'AXI4' ?
+    `    := AXI4Deinterleaver(c.blackbox.cacheBlockBytes)
+         := AXI4IdIndexer(idBits = ${params}.maxFifoBits)` : ''
+}    := TLToAXI4()
+${e.busType.name === 'AXI4Lite' ?
+    `    := TLFragmenter((${dataWidth + ' / 8'}), c.blackbox.cacheBlockBytes, holdFirstDeny=true)` : '\n'
 }
     := TLBuffer(
       a = ${tlBufferParams}.a,
@@ -115,7 +116,7 @@ ${e.busType.name === 'AXI4Lite' ? `
       d = ${tlBufferParams}.d,
       e = ${tlBufferParams}.e
     )
-)
+)}
 `;
 };
 
@@ -158,7 +159,7 @@ const masterAttachGen = comp => e =>
   `bap.pbus.coupleFrom("axi") { _ := TLWidthWidget(bap.pbus) := ${comp.name}_top.${e.name}Node }`;
 
 const slaveAttachGen = comp => e =>
-  `bap.pbus.coupleTo("axi") { ${comp.name}_top.${e.name}Node := TLWidthWidget(bap.pbus) := _ }`;
+  `bap.pbus.coupleTo("axi") { ${comp.name}_top.get${e.name}NodeTLAdapter() := TLWidthWidget(bap.pbus) := _ }`;
 
 const busDef = {
   aw: {

--- a/lib/indent.js
+++ b/lib/indent.js
@@ -8,6 +8,7 @@ module.exports = (tab, sep) => {
     return lines
       .reduce((res, cur) => res.concat(cur.split('\n')), [])
       .map(line => prefix + line)
+      .map(line => line.trim() === '' ? '' : line)
       .join(sep);
   };
 };


### PR DESCRIPTION
Do not emit scala with trailing whitespace. Split TileLink adapter instantiations into separate methods that can be optionally called. Default behavior remains the same.