### PR TITLE
fix bundle bridge nodes

### DIFF
--- a/lib/export-scala-base.js
+++ b/lib/export-scala-base.js
@@ -77,10 +77,14 @@ const perBusInterface = comp => e => {
   return `  val ${e.name}Node = ${handle(comp)(e)}`;
 };
 
-const perBusInterfaceAlias = () => e =>
-  `val ${e.name}0 = ${e.name}Node.${
-    e.interfaceMode == 'slave' ? 'in' : 'out'
-  }(0)._1`;
+const perBusInterfaceAlias = () => e => {
+  const handle = get(
+    generators,
+    [e.busType.name, e.interfaceMode, 'adapter'],
+    null);
+  const direction = handle && (e.interfaceMode == 'slave') ? 'in' : 'out';
+  return `val ${e.name}0 = ${e.name}Node.${direction}(0)._1`;
+};
 
 const perBusInterfaceParams = comp => e => get(
   generators, [e.busType.name, e.interfaceMode, 'params'],
@@ -251,6 +255,8 @@ ${
 }
 )
 
+${comp.busInterfaces.map(perBusInterfaceBundle(comp)).join('\n')}
+
 class L${comp.name}Base(c: ${comp.name}Params)(implicit p: Parameters) extends LazyModule {
   val device = new SimpleDevice("${comp.name}", Seq("sifive,${comp.name}-v0"))
 
@@ -259,8 +265,6 @@ ${indent(2)(paramSchema.reduce({
   })(pSchema))}
 
 ${comp.busInterfaces.map(perBusInterface(comp)).join('\n')}
-
-${comp.busInterfaces.map(perBusInterfaceBundle(comp)).join('\n')}
 
   val ioBridgeSource = BundleBridgeSource(() => new ${comp.name}BlackBoxIO(
 ${indent(4, ',')(paramSchema.reduce({
@@ -332,7 +336,9 @@ ${
       .map(e => get(
         generators,
         [e.busType.name, e.interfaceMode, 'node'],
-        () => () => `// busType: ${e.busType.name}, mode: ${e.interfaceMode}`
+        () => () =>`
+val ${e.name}Node = BundleBridgeSink[${e.name}Bundle]
+${e.name}Node := imp.${e.name}Node`
       )(comp)(e))
   )
 }

--- a/lib/export-scala-base.js
+++ b/lib/export-scala-base.js
@@ -154,12 +154,6 @@ const perBusInterfaceWiring = comp => {
 
         const sig = signValue(node);
 
-        if (sig.sign ^ (e.interfaceMode == 'slave')) {
-          res += `${e.name}0.${tlName} := ${
-            sig.value === 1 ? 'true.B' : '0.U'
-          } // ${busName}\n`;
-          return;
-        }
         res += '// ' + busName + '\n';
       }
     })(bus);

--- a/lib/export-scala-base.js
+++ b/lib/export-scala-base.js
@@ -152,8 +152,6 @@ const perBusInterfaceWiring = comp => {
           return;
         }
 
-        const sig = signValue(node);
-
         res += '// ' + busName + '\n';
       }
     })(bus);

--- a/lib/export-scala-base.js
+++ b/lib/export-scala-base.js
@@ -11,7 +11,6 @@ const spram = require('./spram');
 const dpram = require('./dpram');
 
 const exportScalaChannel = require('./export-scala-channel');
-const signValue = require('./sign-value');
 const traverseSpec = require('./traverse-spec');
 const flipString = require('./flip-string');
 const indent = require('./indent');


### PR DESCRIPTION
- make bundle class definitions visible outside of base module
- connect bundle bridge sources from `LModule` to bundle bridge sinks in `NModule`
- use `out` data values for bundle bridges