### PR TITLE
implement apb attach functions, fix beatBytes param

### DIFF
--- a/lib/apb-scala.js
+++ b/lib/apb-scala.js
@@ -11,6 +11,7 @@ const masterAdapterGen = comp => () => `APBMasterNode(Seq(
 const slaveAdapterGen = comp => e => {
   const params = `c.${e.name}Params`;
   const portMaps = e.abstractionTypes.find(e => e.viewRef === 'RTLview').portMaps;
+  const dataWidth = comp.model.ports.find(p => p.name === portMaps.PRDATA).wire.width;
   const addrWidth = comp.model.ports.find(p => p.name === portMaps.PADDR).wire.width;
   return `APBSlaveNode(Seq(
     APBSlavePortParameters(
@@ -24,7 +25,7 @@ const slaveAdapterGen = comp => e => {
         supportsRead  = true
         // device
       )),
-      beatBytes = 4
+      beatBytes = ${dataWidth} / 8
     )
   ))
 `;
@@ -51,7 +52,7 @@ const slaveNodeGen = comp => e => {
   return `
 val ${e.name}Node: APBSlaveNode = imp.${e.name}Node
 
-def get${e.name}Node(): TLInwardNode = {(
+def get${e.name}NodeTLAdapter(): TLInwardNode = {(
   ${e.name}Node
     := TLToAPB(false)
     := TLBuffer()
@@ -78,19 +79,25 @@ const busDef = {
   pprot: 3
 };
 
+const slaveAttachGen = comp => e =>
+  `bap.pbus.coupleTo("${comp.name}_apb") { ${comp.name}_top.get${e.name}NodeTLAdapter() := TLWidthWidget(bap.pbus) := _ }`;
+
+const masterAttachGen = comp => e =>
+  `bap.pbus.coupleFrom("axi") { _ := TLWidthWidget(bap.pbus) := ${comp.name}_top.${e.name}Node }`;
+
 module.exports = {
   master: {
     adapter: masterAdapterGen,
     // params: masterBusParams,
-    node: masterNodeGen
-    // attach: masterAttachGen,
+    node: masterNodeGen,
+    attach: masterAttachGen
     // wiring: () => () => ''
   },
   slave: {
     adapter: slaveAdapterGen,
     params: slaveBusParams,
-    node: slaveNodeGen
-    // attach: slaveAttachGen,
+    node: slaveNodeGen,
+    attach: slaveAttachGen
     // wiring: () => () => ''
   },
   busDef: busDef,


### PR DESCRIPTION
- implement master and slave attach functions for APB
- change `beatBytes` parameter
- rename adapter function to be consistent with the others

@terpstra is https://github.com/sifive/duh-scala/compare/apb-fixes#diff-058f2975815c455b55ef184c90b78de7R28 the correct value for the `beatBytes` parameter of `APBSlavePortParameters`? I just copied this from axi version.