### PR TITLE
add export-scala-regmap

### DIFF
--- a/bin/duh-export-regmap.js
+++ b/bin/duh-export-regmap.js
@@ -42,7 +42,7 @@ const flow = argv => new Promise (resolve => {
             return;
           } else if (typeof node === 'string') {
 
-            const fileName = `${outputDir}/${path.reverse().join('/')}.scala`;
+            const fileName = `${outputDir}/${path.join('/')}.scala`;
 
             fs.outputFile(fileName, node);
 

--- a/bin/duh-export-regmap.js
+++ b/bin/duh-export-regmap.js
@@ -34,8 +34,8 @@ const flow = argv => new Promise (resolve => {
   if (argv.verbose) console.log('regmap');
   duhCore.readDuh(argv)
     .then(duhCore.expandAll)
-    .then(duh1 => {
-      const emittedRegMappers = lib.exportScalaRegMap(duh1.component);
+    .then(duh => {
+      const emittedRegMappers = lib.exportScalaRegMap(duh.component);
       traverseSpec({
         enter: (node, path) => {
           if (typeof node === 'object') {

--- a/bin/duh-export-regmap.js
+++ b/bin/duh-export-regmap.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const fs = require('fs-extra');
+const yargs = require('yargs');
+const scalametaParsers = require('scalameta-parsers');
+
+const duhCore = require('duh-core');
+
+const lib = require('../lib/index.js');
+const traverseSpec = require('../lib/traverse-spec');
+
+const parseSource = scalametaParsers.parseSource;
+
+const argv = yargs
+  .option('output', {
+    alias: 'o',
+    describe: 'output path for exported files',
+    default: 'component/src'
+  })
+  .option('validate', {
+    alias: 'val',
+    describe: 'validate output Scala',
+    default: false,
+    type: 'boolean'
+  })
+  .version()
+  .help()
+  .argv;
+
+const flow = argv => new Promise (resolve => {
+  const outputDir = argv.output;
+  if (argv.verbose) console.log('regmap');
+  duhCore.readDuh(argv)
+    .then(duhCore.expandAll)
+    .then(duh1 => {
+      const emittedRegMappers = lib.exportScalaRegMap(duh1.component);
+      traverseSpec({
+        enter: (node, path) => {
+          if (typeof node === 'object') {
+            return;
+          } else if (typeof node === 'string') {
+
+            const fileName = `${outputDir}/${path.reverse().join('/')}.scala`;
+
+            fs.outputFile(fileName, node);
+
+            if (argv.validate) {
+              const ast = parseSource.call({}, node);
+              if (ast.error) {
+                console.error(ast);
+                throw new SyntaxError(ast.error);
+              }
+            }
+          }
+        }
+      })(emittedRegMappers);
+      resolve();
+    });
+});
+
+const main = argv => {
+  const cwd = process.cwd();
+  const folderName = path.basename(cwd);
+  const fileName = argv._[0] || folderName + '.json5';
+  flow(Object.assign({filename: fileName}, argv));
+};
+
+main(argv);
+/* eslint no-console: 0 */

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -64,7 +64,7 @@ ${indent(2)(bundleFields.join('\n'))}
 
 //// GNERATE REGROUTER ////
 
-const generateRegisterField = field => scalaRegisterName => {
+const generateRegisterField = (field, scalaRegisterName) => {
   if (field.access) {
     const regFieldDesc = field.name || field.desc ?
       `, RegFieldDesc(${field.name ? `"${field.name}"` : '""'}, ${field.desc ? `"${field.desc}"` : '""'}))` :
@@ -89,12 +89,12 @@ const generateRegisterField = field => scalaRegisterName => {
   }
 };
 
-const generateRegister = register => scalaRegMapBundleName => {
+const generateRegister = (register, scalaRegMapBundleName) => {
   const scalaRegBundleName = `${scalaRegMapBundleName}.${register.name}`;
 
   const regFieldSeqElements = register.fields.map((field, idx) => {
     const scalaBundleField = getScalaBundleRegFieldName(field, idx);
-    return generateRegisterField(field)(`${scalaRegBundleName}.${scalaBundleField}`);
+    return generateRegisterField(field, `${scalaRegBundleName}.${scalaBundleField}`);
   });
 
   const registerDesc = register.description ? `Some("${register.description}")` : 'None';
@@ -103,11 +103,11 @@ const generateRegister = register => scalaRegMapBundleName => {
 ${indent(2)(regFieldSeqElements.join(',\n'))}))`;
 };
 
-const generateBody = addressBlock => packageName => {
+const generateBody = (addressBlock, packageName) => {
   const scalaRegMapBundleName = 'register';
 
   const registerMapElements = addressBlock.registers.map((register) => {
-    return generateRegister(register)(scalaRegMapBundleName);
+    return generateRegister(register, scalaRegMapBundleName);
   });
 
   const bundleDefs = generateAddressBlockBundles(addressBlock);
@@ -174,7 +174,7 @@ const exportRegmap = comp => {
     let memoryMapResult = {};
     addressBlocks.forEach((addressBlock) => {
       const packageName = `${packageNameBase}.${memoryMap.name}.${addressBlock.name}`;
-      memoryMapResult[addressBlock.name] = generateBody(addressBlock)(packageName);
+      memoryMapResult[addressBlock.name] = generateBody(addressBlock, packageName);
     });
 
     result[memoryMap.name] = memoryMapResult;

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -163,7 +163,7 @@ class ${addressBlock.name}AXI4RegMap(busWidthBytes: Int, baseAddress: Long)(impl
 };
 
 
-module.exports = comp => {
+const exportRegmap = comp => {
   const memoryMaps = comp.memoryMaps || [];
 
   let result = {};
@@ -182,3 +182,5 @@ module.exports = comp => {
 
   return result;
 };
+
+module.exports = exportRegmap;

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -67,7 +67,7 @@ const generateRegisterField = field => scalaRegisterName => {
       case 'writeOnce':
         return `RegField(${field.bits}, Unit, regFieldWriteOnceFn(${scalaRegisterName})${regFieldDesc}`;
       default:
-        throw new Error(`invalide access field value: ${field.access}`);
+        throw new Error(`invalid access field value: ${field.access}`);
     }
   } else {
     return `RegField(${field.bits})`;

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -103,7 +103,8 @@ ${indent(2)(regFieldSeqElements.join(',\n'))}))`;
 };
 
 const generateRegisterResetParams = (register, addressBlockNames) => {
-  const baseParamsName = `${addressBlockNames.baseParamsObject}.resetValues.${register.name}`;
+  const baseParamsName =
+    `${addressBlockNames.baseParamsObject.name}.${addressBlockNames.baseParamsObject.resetValues}.${register.name}`;
 
   const registerResetValues = getRegisterFields(register).map((field, idx) => {
     const paramName = getScalaBundleRegFieldName(field, idx);
@@ -132,7 +133,8 @@ ${indent(2)(registerResetValues.join('\n'))}
 
 const generateRegisterReset = (access, register, addressBlockNames) => {
   const scalaRegBundleName = `${addressBlockNames.regMapResetWire}.${register.name}`;
-  const resetBundleName = `${addressBlockNames.userParamsObject}.resetValues.${register.name}`;
+  const resetBundleName =
+    `${addressBlockNames.userParamsObject.name}.${addressBlockNames.userParamsObject.resetValues}.${register.name}`;
 
   const regFieldSeqElements = getRegisterFields(register).map((field, idx) => {
     const scalaBundleField = getScalaBundleRegFieldName(field, idx);
@@ -148,8 +150,18 @@ const getAddressBlockNames = addressBlock => {
   const regRouterName = `${addressBlock.name}RegRouter`;
   return {
     regRouter: regRouterName,
-    baseParamsObject: `${regRouterName}Base`,
-    userParamsObject: `${regRouterName}User`,
+    baseParamsObject: {
+      name: `${regRouterName}Base`,
+      resetValues: 'resetValues',
+      deviceTreeName: 'deviceTreeName',
+      deviceTreeCompat: 'deviceTreeCompat'
+    },
+    userParamsObject: {
+      name: `${regRouterName}User`,
+      resetValues: 'resetValues',
+      deviceTreeName: 'deviceTreeName',
+      deviceTreeCompat: 'deviceTreeCompat'
+    },
     ioBundle: `${addressBlock.name}AddressBlockBundle`,
     regMapRegister: 'register',
     regMapResetWire: 'resetValue',
@@ -158,9 +170,7 @@ const getAddressBlockNames = addressBlock => {
   };
 };
 
-const generateBodyBase = (addressBlock, packageName, deviceNameString, compatString) => {
-  const names = getAddressBlockNames(addressBlock);
-
+const generateBodyBase = (names, addressBlock, packageName, deviceNameString, compatString) => {
   const registerMapElements = addressBlock.registers.map((register) => {
     return generateRegister(register.access || addressBlock.access, register, names);
   });
@@ -191,11 +201,11 @@ import freechips.rocketchip.amba.axi4.HasAXI4ControlRegMap
 
 ${bundleDefs}
 
-object ${names.baseParamsObject} {
-  def deviceName: String = ${deviceNameString}
-  def deviceCompat: Seq[String] = Seq(${compatString})
+object ${names.baseParamsObject.name} {
+  def ${names.baseParamsObject.deviceTreeName}: String = ${deviceNameString}
+  def ${names.baseParamsObject.deviceTreeCompat}: Seq[String] = Seq(${compatString})
 
-  object resetValues {
+  object ${names.baseParamsObject.resetValues} {
 ${indent(4)(resetParamElements.join('\n\n'))}
   }
 }
@@ -203,8 +213,8 @@ ${indent(4)(resetParamElements.join('\n\n'))}
 abstract class ${names.regRouter}(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
   extends IORegisterRouter(
     RegisterRouterParams(
-      name = ${names.baseParamsObject}.deviceName,
-      compat = ${names.baseParamsObject}.deviceCompat,
+      name = ${names.userParamsObject.name}.${names.userParamsObject.deviceTreeName},
+      compat = ${names.userParamsObject.name}.${names.userParamsObject.deviceTreeCompat},
       base = baseAddress,
       beatBytes = busWidthBytes),
     new ${names.ioBundle}) {
@@ -231,9 +241,7 @@ class ${names.axi4RegMap}AXI4RegMap(busWidthBytes: Int, baseAddress: Long)(impli
 `;
 };
 
-const generateBodyUser = (addressBlock, packageName) => {
-  const names = getAddressBlockNames(addressBlock);
-
+const generateBodyUser = (names, addressBlock, packageName) => {
   const resetParamElements = addressBlock.registers.map((register) => {
     return generateRegisterResetParams(register, names);
   });
@@ -242,11 +250,11 @@ const generateBodyUser = (addressBlock, packageName) => {
 
 import chisel3._
 
-object ${names.userParamsObject} {
-  def deviceName: String = ${names.baseParamsObject}.deviceName
-  def deviceCompat: Seq[String] = ${names.baseParamsObject}.deviceCompat
+object ${names.userParamsObject.name} {
+  def ${names.userParamsObject.deviceTreeName}: String = ${names.baseParamsObject.name}.${names.baseParamsObject.deviceTreeName}
+  def ${names.userParamsObject.deviceTreeCompat}: Seq[String] = ${names.baseParamsObject.name}.${names.baseParamsObject.deviceTreeCompat}
 
-  object resetValues {
+  object ${names.userParamsObject.resetValues} {
 ${indent(4)(resetParamElements.join('\n\n'))}
   }
 }
@@ -268,8 +276,10 @@ const exportRegmap = comp => {
       const packageName = `${packageNameBase}.${memoryMap.name}.${addressBlock.name}`;
       const compatString = `"${comp.vendor},${comp.name}-${comp.version}"`;
       const deviceNameString = `"${comp.name}-${addressBlock.name}"`;
-      memoryMapBaseResult[`${addressBlock.name}-base`] = generateBodyBase(addressBlock, packageName, deviceNameString, compatString);
-      memoryMapUserResult[addressBlock.name] = generateBodyUser(addressBlock, packageName);
+      const names = getAddressBlockNames(addressBlock);
+
+      memoryMapBaseResult[`${addressBlock.name}-base`] = generateBodyBase(names, addressBlock, packageName, deviceNameString, compatString);
+      memoryMapUserResult[addressBlock.name] = generateBodyUser(names, addressBlock, packageName);
     });
 
     baseResult[memoryMap.name] = memoryMapBaseResult;

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -105,9 +105,11 @@ ${indent(2)(regFieldSeqElements.join(',\n'))}))`;
 };
 
 const getAddressBlockNames = addressBlock => {
+  const regRouterName = `${addressBlock.name}RegRouter`;
   return {
-    regRouter: `${addressBlock.name}RegRouter`,
-    defaultParamsObject: `${this.regRouter}Defaults`,
+    regRouter: regRouterName,
+    baseParamsObject: `${regRouterName}Base`,
+    userParamsObject: `${regRouterName}User`,
     ioBundle: `${addressBlock.name}AddressBlockBundle`,
     regMapRegister: 'register',
     tlRegMap: `${addressBlock.name}TLRegMap`,
@@ -115,7 +117,7 @@ const getAddressBlockNames = addressBlock => {
   };
 };
 
-const generateBodyBase = (addressBlock, packageName, compatString) => {
+const generateBodyBase = (addressBlock, packageName, deviceNameString, compatString) => {
   const names = getAddressBlockNames(addressBlock);
 
   const registerMapElements = addressBlock.registers.map((register) => {
@@ -140,16 +142,16 @@ import freechips.rocketchip.amba.axi4.HasAXI4ControlRegMap
 
 ${bundleDefs}
 
-object ${names.defaultParamsObject} {
-  def name: String = "${addressBlock.name}"
-  def compat: Seq[String] = Seq(${compatString})
+object ${names.baseParamsObject} {
+  def deviceName: String = ${deviceNameString}
+  def deviceCompat: Seq[String] = Seq(${compatString})
 }
 
 abstract class ${names.regRouter}(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
   extends IORegisterRouter(
     RegisterRouterParams(
-      name = ${names.defaultParamsObject}.name,
-      compat = ${names.defaultParamsObject}.compat,
+      name = ${names.baseParamsObject}.deviceName,
+      compat = ${names.baseParamsObject}.deviceCompat,
       base = baseAddress,
       beatBytes = busWidthBytes),
     new ${names.ioBundle}) {
@@ -172,6 +174,18 @@ class ${names.axi4RegMap}AXI4RegMap(busWidthBytes: Int, baseAddress: Long)(impli
 `;
 };
 
+const generateBodyUser = (addressBlock, packageName, compatString) => {
+  const names = getAddressBlockNames(addressBlock);
+
+  return `${packageName}
+
+object ${names.userParamsObject} {
+  def deviceName: String = ${names.baseParamsObject}.deviceName
+  def deviceCompat: Seq[String] = ${names.baseParamsObject}.deviceCompat
+}
+`;
+}
+
 const exportRegmap = comp => {
   const memoryMaps = comp.memoryMaps || [];
 
@@ -184,7 +198,9 @@ const exportRegmap = comp => {
     addressBlocks.forEach((addressBlock) => {
       const packageName = `${packageNameBase}.${memoryMap.name}.${addressBlock.name}`;
       const compatString = `"${comp.vendor},${comp.name}-${comp.version}"`;
-      memoryMapResult[addressBlock.name] = generateBodyBase(addressBlock, packageName, compatString);
+      const deviceNameString = `"${comp.name}-${addressBlock.name}"`;
+      memoryMapResult[`${addressBlock.name}-base`] = generateBodyBase(addressBlock, packageName, deviceNameString, compatString);
+      memoryMapResult[addressBlock.name] = generateBodyUser(addressBlock, packageName, compatString);
     });
 
     result[memoryMap.name] = memoryMapResult;

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -20,8 +20,8 @@ const generateRegisterBundle = (access, register) => {
   const direction = (access => {
     switch (access) {
     case 'read-write':
-    case 'write-only':
     case 'read-writeOnce':
+    case 'write-only':
     case 'writeOnce':
       return 'Output';
     case 'read-only':
@@ -107,7 +107,7 @@ const generateRegister = (access, register, scalaRegMapBundleName) => {
 ${indent(2)(regFieldSeqElements.join(',\n'))}))`;
 };
 
-const generateBody = (addressBlock, packageName) => {
+const generateBody = (addressBlock, packageName, compatString) => {
   const scalaRegMapBundleName = 'register';
 
   const registerMapElements = addressBlock.registers.map((register) => {
@@ -115,6 +115,8 @@ const generateBody = (addressBlock, packageName) => {
   });
 
   const bundleDefs = generateAddressBlockBundles(addressBlock);
+
+  const className = `${addressBlock.name}RegRouter`
 
   return `// Generated Code
 // Please DO NOT EDIT
@@ -132,11 +134,16 @@ import freechips.rocketchip.amba.axi4.HasAXI4ControlRegMap
 
 ${bundleDefs}
 
-abstract class ${addressBlock.name}RegRouter(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
+${className}Defaults {
+  def name: String = "${addressBlock.name}"
+  def compat: Seq[String] = Seq("${compatString}")
+}
+
+abstract class ${className}(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
   extends IORegisterRouter(
     RegisterRouterParams(
-      name = "${addressBlock.name}",
-      compat = Seq.empty,
+      name = ${className}.name,
+      compat = ${className}.compat,
       base = baseAddress,
       beatBytes = busWidthBytes),
     new ${getScalaAddressBlockBundleName(addressBlock)}) {

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -88,13 +88,8 @@ const generateRegisterField = (field, scalaRegisterName, access) => {
   }
 };
 
-const generateRegisterFieldReset = (field, scalaRegisterName, access) => {
-  const resetValue = '0.U';
-  return access ? `${scalaRegisterName} := ${resetValue}` : `RegField(${field.bits})`;
-};
-
-const generateRegister = (access, register, scalaRegMapBundleName) => {
-  const scalaRegBundleName = `${scalaRegMapBundleName}.${register.name}`;
+const generateRegister = (access, register, addressBlockNames) => {
+  const scalaRegBundleName = `${addressBlockNames.regMapResetWire}.${register.name}`;
 
   const regFieldSeqElements = getRegisterFields(register).map((field, idx) => {
     const scalaBundleField = getScalaBundleRegFieldName(field, idx);
@@ -107,12 +102,43 @@ const generateRegister = (access, register, scalaRegMapBundleName) => {
 ${indent(2)(regFieldSeqElements.join(',\n'))}))`;
 };
 
-const generateRegisterReset = (access, register, scalaRegMapBundleName) => {
-  const scalaRegBundleName = `${scalaRegMapBundleName}.${register.name}`;
+const generateRegisterResetParams = (register, addressBlockNames) => {
+  const baseParamsName = `${addressBlockNames.baseParamsObject}.resetValues.${register.name}`;
+
+  const registerResetValues = getRegisterFields(register).map((field, idx) => {
+    const paramName = getScalaBundleRegFieldName(field, idx);
+    return `def ${paramName}: UInt =
+  ${baseParamsName}.${paramName}`;
+  });
+
+  const objectName = register.name;
+  return `object ${objectName} {
+${indent(2)(registerResetValues.join('\n'))}
+}`;
+};
+
+const generateRegisterResetBaseParams = (register) => {
+  const registerResetValues = getRegisterFields(register).map((field, idx) => {
+    const resetValue = '0.U';
+    const paramName = getScalaBundleRegFieldName(field, idx);
+    return `def ${paramName}: UInt = ${resetValue}`;
+  });
+
+  const objectName = register.name;
+  return `object ${objectName} {
+${indent(2)(registerResetValues.join('\n'))}
+}`;
+};
+
+const generateRegisterReset = (access, register, addressBlockNames) => {
+  const scalaRegBundleName = `${addressBlockNames.regMapResetWire}.${register.name}`;
+  const resetBundleName = `${addressBlockNames.userParamsObject}.resetValues.${register.name}`;
 
   const regFieldSeqElements = getRegisterFields(register).map((field, idx) => {
     const scalaBundleField = getScalaBundleRegFieldName(field, idx);
-    return generateRegisterFieldReset(field, `${scalaRegBundleName}.${scalaBundleField}`, field.access || access);
+    const resetValue = `${resetBundleName}.${scalaBundleField}`;
+    const resetWire = `${scalaRegBundleName}.${scalaBundleField}`;
+    return access ? `${resetWire} := ${resetValue}` : `RegField(${field.bits})`;
   });
 
   return regFieldSeqElements.join('\n');
@@ -136,11 +162,15 @@ const generateBodyBase = (addressBlock, packageName, deviceNameString, compatStr
   const names = getAddressBlockNames(addressBlock);
 
   const registerMapElements = addressBlock.registers.map((register) => {
-    return generateRegister(register.access || addressBlock.access, register, names.regMapRegister);
+    return generateRegister(register.access || addressBlock.access, register, names);
   });
 
   const resetElements = addressBlock.registers.map((register) => {
-    return generateRegisterReset(register.access || addressBlock.access, register, names.regMapResetWire);
+    return generateRegisterReset(register.access || addressBlock.access, register, names);
+  });
+
+  const resetParamElements = addressBlock.registers.map((register) => {
+    return generateRegisterResetBaseParams(register);
   });
 
   const bundleDefs = generateAddressBlockBundles(addressBlock);
@@ -164,6 +194,10 @@ ${bundleDefs}
 object ${names.baseParamsObject} {
   def deviceName: String = ${deviceNameString}
   def deviceCompat: Seq[String] = Seq(${compatString})
+
+  object resetValues {
+${indent(4)(resetParamElements.join('\n\n'))}
+  }
 }
 
 abstract class ${names.regRouter}(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
@@ -200,11 +234,21 @@ class ${names.axi4RegMap}AXI4RegMap(busWidthBytes: Int, baseAddress: Long)(impli
 const generateBodyUser = (addressBlock, packageName) => {
   const names = getAddressBlockNames(addressBlock);
 
+  const resetParamElements = addressBlock.registers.map((register) => {
+    return generateRegisterResetParams(register, names);
+  });
+
   return `${packageName}
+
+import chisel3._
 
 object ${names.userParamsObject} {
   def deviceName: String = ${names.baseParamsObject}.deviceName
   def deviceCompat: Seq[String] = ${names.baseParamsObject}.deviceCompat
+
+  object resetValues {
+${indent(4)(resetParamElements.join('\n\n'))}
+  }
 }
 `;
 };

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -120,7 +120,7 @@ ${indent(2)(registerResetValues.join('\n'))}
 
 const generateRegisterResetBaseParams = (register) => {
   const registerResetValues = getRegisterFields(register).map((field, idx) => {
-    const resetValue = '0.U';
+    const resetValue = field.resetValue ? `${field.resetValue}.U` : '0.U';
     const paramName = getScalaBundleRegFieldName(field, idx);
     return `def ${paramName}: UInt = ${resetValue}`;
   });

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -78,15 +78,13 @@ const generateRegisterField = (field, scalaRegisterName, access) => {
 
     switch (access) {
     case 'read-write':
+    case 'read-writeOnce':
       return `RegField(${field.bits}, ${scalaRegisterName}, ${regFieldDesc})`;
     case 'read-only':
       return `RegField.r(${field.bits}, ${scalaRegisterName}, ${regFieldDesc})`;
     case 'write-only':
-      return `RegField.w(${field.bits}, ${scalaRegisterName}, ${regFieldDesc})`;
-    case 'read-writeOnce':
-      return `RegField(${field.bits}, ${scalaRegisterName}, regFieldWriteOnceFn(${scalaRegisterName}), ${regFieldDesc})`;
     case 'writeOnce':
-      return `RegField(${field.bits}, (), regFieldWriteOnceFn(${scalaRegisterName}), ${regFieldDesc})`;
+      return `RegField.w(${field.bits}, ${scalaRegisterName}, ${regFieldDesc})`;
     default:
       throw new Error(`invalid access field value: ${access}`);
     }
@@ -138,17 +136,6 @@ abstract class ${addressBlock.name}RegRouter(busWidthBytes: Int, baseAddress: Lo
       base = baseAddress,
       beatBytes = busWidthBytes),
     new ${getScalaAddressBlockBundleName(addressBlock)}) {
-
-  private def regFieldWriteOnceFn(register: UInt): RegWriteFn = {
-    val written = RegInit(false.B)
-    RegWriteFn((valid, data) => {
-      when (valid && !written) {
-        register := data
-        written := true.B
-      }
-      true.B
-    })
-  }
 
   lazy val module = new LazyModuleImp(this) {
     val portValue = ioNode.makeIO()

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -6,16 +6,15 @@ const indent = require('./indent');
 
 const getScalaBundleRegFieldName = (field, idx) => {
   return field.name ? field.name : `reserved${idx}`;
-}
+};
 
 const getScalaRegisterBundleName = (register) => {
   return `${register.name}RegisterBundle`;
-}
+};
 
 const generateRegisterBundle = register => {
   const fields = register.fields.map((field, idx) => {
-    register.fields
-    return `val ${getScalaBundleRegFieldName(field, idx)} = UInt(${field.bits}.W)`
+    return `val ${getScalaBundleRegFieldName(field, idx)} = UInt(${field.bits}.W)`;
   });
 
   return `class ${getScalaRegisterBundleName(register)} extends Bundle {
@@ -26,24 +25,22 @@ ${indent(2)(fields.join('\n'))}
 
 const getScalaAddressBlockBundleName = (addressBlock) => {
   return `${addressBlock.name}AddressBlockBundle`;
-}
+};
 
 const generateAddressBlockBundles = addressBlock => {
   const registerBundles = addressBlock.registers.map((register) => {
     return generateRegisterBundle(register);
-  })
+  });
 
   const bundleFields = addressBlock.registers.map((register) => {
     return `val ${register.name} = new ${getScalaRegisterBundleName(register)}()`;
-  })
+  });
 
-  return `
-${registerBundles.join('\n\n')}
+  return `${registerBundles.join('\n\n')}
 
 class ${getScalaAddressBlockBundleName(addressBlock)} extends Bundle {
 ${indent(2)(bundleFields.join('\n'))}
-}
-`;
+}`;
 };
 
 
@@ -56,18 +53,18 @@ const generateRegisterField = field => scalaRegisterName => {
       ')';
 
     switch (field.access) {
-      case 'read-write':
-        return `RegField(${field.bits}, ${scalaRegisterName}${regFieldDesc}`;
-      case 'read-only':
-        return `RegField.r(${field.bits}, ${scalaRegisterName}${regFieldDesc}`;
-      case 'write-only':
-        return `RegField.w(${field.bits}, ${scalaRegisterName}${regFieldDesc})`;
-      case 'read-writeOnce':
-        return `RegField(${field.bits}, ${scalaRegisterName}, regFieldWriteOnceFn(${scalaRegisterName})${regFieldDesc}`;
-      case 'writeOnce':
-        return `RegField(${field.bits}, Unit, regFieldWriteOnceFn(${scalaRegisterName})${regFieldDesc}`;
-      default:
-        throw new Error(`invalid access field value: ${field.access}`);
+    case 'read-write':
+      return `RegField(${field.bits}, ${scalaRegisterName}${regFieldDesc}`;
+    case 'read-only':
+      return `RegField.r(${field.bits}, ${scalaRegisterName}${regFieldDesc}`;
+    case 'write-only':
+      return `RegField.w(${field.bits}, ${scalaRegisterName}${regFieldDesc})`;
+    case 'read-writeOnce':
+      return `RegField(${field.bits}, ${scalaRegisterName}, regFieldWriteOnceFn(${scalaRegisterName})${regFieldDesc}`;
+    case 'writeOnce':
+      return `RegField(${field.bits}, Unit, regFieldWriteOnceFn(${scalaRegisterName})${regFieldDesc}`;
+    default:
+      throw new Error(`invalid access field value: ${field.access}`);
     }
   } else {
     return `RegField(${field.bits})`;
@@ -75,10 +72,10 @@ const generateRegisterField = field => scalaRegisterName => {
 };
 
 const generateRegister = register => scalaRegMapBundleName => {
-  const scalaRegBundleName = `${scalaRegMapBundleName}.${register.name}`
+  const scalaRegBundleName = `${scalaRegMapBundleName}.${register.name}`;
 
   const regFieldSeqElements = register.fields.map((field, idx) => {
-    const scalaBundleField = getScalaBundleRegFieldName(field, idx)
+    const scalaBundleField = getScalaBundleRegFieldName(field, idx);
     return generateRegisterField(field)(`${scalaRegBundleName}.${scalaBundleField}`);
   });
 

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -256,24 +256,30 @@ ${indent(4)(resetParamElements.join('\n\n'))}
 const exportRegmap = comp => {
   const memoryMaps = comp.memoryMaps || [];
 
-  let result = {};
+  let baseResult = {};
+  let userResult = {};
   const packageNameBase = `package ${comp.vendor}.${comp.library}.${comp.name}`;
   memoryMaps.forEach((memoryMap) => {
     const addressBlocks = memoryMap.addressBlocks;
 
-    let memoryMapResult = {};
+    let memoryMapUserResult = {};
+    let memoryMapBaseResult = {};
     addressBlocks.forEach((addressBlock) => {
       const packageName = `${packageNameBase}.${memoryMap.name}.${addressBlock.name}`;
       const compatString = `"${comp.vendor},${comp.name}-${comp.version}"`;
       const deviceNameString = `"${comp.name}-${addressBlock.name}"`;
-      memoryMapResult[`${addressBlock.name}-base`] = generateBodyBase(addressBlock, packageName, deviceNameString, compatString);
-      memoryMapResult[addressBlock.name] = generateBodyUser(addressBlock, packageName);
+      memoryMapBaseResult[`${addressBlock.name}-base`] = generateBodyBase(addressBlock, packageName, deviceNameString, compatString);
+      memoryMapUserResult[addressBlock.name] = generateBodyUser(addressBlock, packageName);
     });
 
-    result[memoryMap.name] = memoryMapResult;
+    baseResult[memoryMap.name] = memoryMapBaseResult;
+    userResult[memoryMap.name] = memoryMapUserResult;
   });
 
-  return result;
+  return {
+    base: baseResult,
+    user: userResult
+  };
 };
 
 module.exports = exportRegmap;

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -14,9 +14,9 @@ const getScalaRegisterBundleName = (register) => {
 
 const generateRegisterBundle = register => {
   const fields = register.fields.map((field, idx) => {
-    if (field.access) {
+    if (register.access) {
       var direction = '';
-      switch (field.access) {
+      switch (access) {
       case 'read-write':
       case 'write-only':
       case 'read-writeOnce':
@@ -64,13 +64,13 @@ ${indent(2)(bundleFields.join('\n'))}
 
 //// GNERATE REGROUTER ////
 
-const generateRegisterField = (field, scalaRegisterName) => {
-  if (field.access) {
+const generateRegisterField = (field, scalaRegisterName, access) => {
+  if (access) {
     const regFieldDesc = field.name || field.desc ?
       `, RegFieldDesc(${field.name ? `"${field.name}"` : '""'}, ${field.desc ? `"${field.desc}"` : '""'}))` :
       ')';
 
-    switch (field.access) {
+    switch (access) {
     case 'read-write':
       return `RegField(${field.bits}, ${scalaRegisterName}${regFieldDesc}`;
     case 'read-only':
@@ -82,7 +82,7 @@ const generateRegisterField = (field, scalaRegisterName) => {
     case 'writeOnce':
       return `RegField(${field.bits}, (), regFieldWriteOnceFn(${scalaRegisterName})${regFieldDesc}`;
     default:
-      throw new Error(`invalid access field value: ${field.access}`);
+      throw new Error(`invalid access field value: ${access}`);
     }
   } else {
     return `RegField(${field.bits})`;
@@ -94,7 +94,7 @@ const generateRegister = (register, scalaRegMapBundleName) => {
 
   const regFieldSeqElements = register.fields.map((field, idx) => {
     const scalaBundleField = getScalaBundleRegFieldName(field, idx);
-    return generateRegisterField(field, `${scalaRegBundleName}.${scalaBundleField}`);
+    return generateRegisterField(field, `${scalaRegBundleName}.${scalaBundleField}`, register.access);
   });
 
   const registerDesc = register.description ? `Some("${register.description}")` : 'None';

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -89,7 +89,7 @@ const generateRegisterField = (field, scalaRegisterName, access) => {
 };
 
 const generateRegisterFieldReset = (field, scalaRegisterName, access) => {
-  const resetValue = "0.U";
+  const resetValue = '0.U';
   return access ? `${scalaRegisterName} := ${resetValue}` : `RegField(${field.bits})`;
 };
 
@@ -197,7 +197,7 @@ class ${names.axi4RegMap}AXI4RegMap(busWidthBytes: Int, baseAddress: Long)(impli
 `;
 };
 
-const generateBodyUser = (addressBlock, packageName, compatString) => {
+const generateBodyUser = (addressBlock, packageName) => {
   const names = getAddressBlockNames(addressBlock);
 
   return `${packageName}
@@ -207,7 +207,7 @@ object ${names.userParamsObject} {
   def deviceCompat: Seq[String] = ${names.baseParamsObject}.deviceCompat
 }
 `;
-}
+};
 
 const exportRegmap = comp => {
   const memoryMaps = comp.memoryMaps || [];
@@ -223,7 +223,7 @@ const exportRegmap = comp => {
       const compatString = `"${comp.vendor},${comp.name}-${comp.version}"`;
       const deviceNameString = `"${comp.name}-${addressBlock.name}"`;
       memoryMapResult[`${addressBlock.name}-base`] = generateBodyBase(addressBlock, packageName, deviceNameString, compatString);
-      memoryMapResult[addressBlock.name] = generateBodyUser(addressBlock, packageName, compatString);
+      memoryMapResult[addressBlock.name] = generateBodyUser(addressBlock, packageName);
     });
 
     result[memoryMap.name] = memoryMapResult;

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -1,0 +1,168 @@
+'use strict';
+
+const indent = require('./indent');
+
+//// GNERATE BUNDLES ////
+
+const getScalaBundleRegFieldName = (field, idx) => {
+  return field.name ? field.name : `reserved${idx}`;
+}
+
+const getScalaRegisterBundleName = (register) => {
+  return `${register.name}RegisterBundle`;
+}
+
+const generateRegisterBundle = register => {
+  const fields = register.fields.map((field, idx) => {
+    register.fields
+    return `val ${getScalaBundleRegFieldName(field, idx)} = UInt(${field.bits}.W)`
+  });
+
+  return `class ${getScalaRegisterBundleName(register)} extends Bundle {
+${indent(2)(fields.join('\n'))}
+}`;
+};
+
+
+const getScalaAddressBlockBundleName = (addressBlock) => {
+  return `${addressBlock.name}AddressBlockBundle`;
+}
+
+const generateAddressBlockBundles = addressBlock => {
+  const registerBundles = addressBlock.registers.map((register) => {
+    return generateRegisterBundle(register);
+  })
+
+  const bundleFields = addressBlock.registers.map((register) => {
+    return `val ${register.name} = new ${getScalaRegisterBundleName(register)}()`;
+  })
+
+  return `
+${registerBundles.join('\n\n')}
+
+class ${getScalaAddressBlockBundleName(addressBlock)} extends Bundle {
+${indent(2)(bundleFields.join('\n'))}
+}
+`;
+};
+
+
+//// GNERATE REGROUTER ////
+
+const generateRegisterField = field => scalaRegisterName => {
+  if (field.access) {
+    const regFieldDesc = field.name || field.desc ?
+      `, RegFieldDesc(${field.name ? `"${field.name}"` : '""'}, ${field.desc ? `"${field.desc}"` : '""'}))` :
+      ')';
+
+    switch (field.access) {
+      case 'read-write':
+        return `RegField(${field.bits}, ${scalaRegisterName}${regFieldDesc}`;
+      case 'read-only':
+        return `RegField.r(${field.bits}, ${scalaRegisterName}${regFieldDesc}`;
+      case 'write-only':
+        return `RegField.w(${field.bits}, ${scalaRegisterName}${regFieldDesc})`;
+      case 'read-writeOnce':
+        return `RegField(${field.bits}, ${scalaRegisterName}, regFieldWriteOnceFn(${scalaRegisterName})${regFieldDesc}`;
+      case 'writeOnce':
+        return `RegField(${field.bits}, Unit, regFieldWriteOnceFn(${scalaRegisterName})${regFieldDesc}`;
+      default:
+        throw new Error(`invalide access field value: ${field.access}`);
+    }
+  } else {
+    return `RegField(${field.bits})`;
+  }
+};
+
+const generateRegister = register => scalaRegMapBundleName => {
+  const scalaRegBundleName = `${scalaRegMapBundleName}.${register.name}`
+
+  const regFieldSeqElements = register.fields.map((field, idx) => {
+    const scalaBundleField = getScalaBundleRegFieldName(field, idx)
+    return generateRegisterField(field)(`${scalaRegBundleName}.${scalaBundleField}`);
+  });
+
+  const registerDesc = register.description ? `Some("${register.description}")` : 'None';
+
+  return `${register.addressOffset} -> RegFieldGroup("${register.name}", ${registerDesc}, Seq(
+${indent(2)(regFieldSeqElements.join(',\n'))}))`;
+};
+
+const generateBody = addressBlock => packageName => {
+  const scalaRegMapBundleName = 'register';
+
+  const registerMapElements = addressBlock.registers.map((register) => {
+    return generateRegister(register)(scalaRegMapBundleName);
+  });
+
+  const bundleDefs = generateAddressBlockBundles(addressBlock);
+
+  return `${packageName}
+
+import chisel3._
+
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy.LazyModuleImp
+import freechips.rocketchip.regmapper._
+import freechips.rocketchip.tilelink.HasTLControlRegMap
+import freechips.rocketchip.amba.axi4.HasAXI4ControlRegMap
+
+${bundleDefs}
+
+abstract class ${addressBlock.name}RegRouter(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
+  extends IORegisterRouter(
+    RegisterRouterParams(
+      name = "${addressBlock.name}",
+      compat = Seq.empty,
+      base = baseAddress,
+      beatBytes = busWidthBytes),
+    new ${getScalaAddressBlockBundleName(addressBlock)}) {
+
+  private def regFieldWriteOnceFn(register: UInt): RegWriteFn = {
+    val written = RegInit(false.B)
+    RegWriteFn((valid, data) => {
+      when (valid && !written) {
+        register := data
+        written := true.B
+      }
+      true.B
+    })
+  }
+
+  lazy val module = new LazyModuleImp(this) {
+    val portValue = port.getWrappedValue
+    val ${scalaRegMapBundleName} = RegInit(0.U.asTypeOf(portValue))
+    portValue <> ${scalaRegMapBundleName}
+    regmap(
+${indent(6)(registerMapElements.join(',\n'))})
+  }
+}
+
+class ${addressBlock.name}TLRegMap(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
+  extends ${addressBlock.name}RegRouter(busWidthBytes, baseAddress) with HasTLControlRegMap
+
+class ${addressBlock.name}AXI4RegMap(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
+  extends ${addressBlock.name}RegRouter(busWidthBytes, baseAddress) with HasAXI4ControlRegMap
+`;
+};
+
+
+module.exports = comp => {
+  const memoryMaps = comp.memoryMaps || [];
+
+  let result = {};
+  const packageNameBase = `package ${comp.vendor}.${comp.library}.${comp.name}`;
+  memoryMaps.forEach((memoryMap) => {
+    const addressBlocks = memoryMap.addressBlocks || [];
+
+    let memoryMapResult = {};
+    addressBlocks.forEach((addressBlock) => {
+      const packageName = `${packageNameBase}.${memoryMap.name}.${addressBlock.name}`;
+      memoryMapResult[addressBlock.name] = generateBody(addressBlock)(packageName);
+    });
+
+    result[memoryMap.name] = memoryMapResult;
+  });
+
+  return result;
+};

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -116,7 +116,11 @@ const generateBody = (addressBlock, packageName) => {
 
   const bundleDefs = generateAddressBlockBundles(addressBlock);
 
-  return `${packageName}
+  return `// Generated Code
+// Please DO NOT EDIT
+
+
+${packageName}
 
 import chisel3._
 

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -12,8 +12,12 @@ const getScalaRegisterBundleName = (register) => {
   return `${register.name}RegisterBundle`;
 };
 
+const getRegisterFields = register => {
+  return registerFields = register.fields || [{bits: register.size}];
+};
+
 const generateRegisterBundle = register => {
-  const fields = register.fields.map((field, idx) => {
+  const fields = getRegisterFields(register).map((field, idx) => {
     if (register.access) {
       var direction = '';
       switch (access) {
@@ -92,7 +96,7 @@ const generateRegisterField = (field, scalaRegisterName, access) => {
 const generateRegister = (register, scalaRegMapBundleName) => {
   const scalaRegBundleName = `${scalaRegMapBundleName}.${register.name}`;
 
-  const regFieldSeqElements = register.fields.map((field, idx) => {
+  const regFieldSeqElements = getRegisterFields(register).fields.map((field, idx) => {
     const scalaBundleField = getScalaBundleRegFieldName(field, idx);
     return generateRegisterField(field, `${scalaRegBundleName}.${scalaBundleField}`, register.access);
   });

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -169,7 +169,7 @@ const exportRegmap = comp => {
   let result = {};
   const packageNameBase = `package ${comp.vendor}.${comp.library}.${comp.name}`;
   memoryMaps.forEach((memoryMap) => {
-    const addressBlocks = memoryMap.addressBlocks || [];
+    const addressBlocks = memoryMap.addressBlocks;
 
     let memoryMapResult = {};
     addressBlocks.forEach((addressBlock) => {

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -13,14 +13,14 @@ const getScalaRegisterBundleName = (register) => {
 };
 
 const getRegisterFields = register => {
-  return registerFields = register.fields || [{bits: register.size}];
+  return register.fields || [{bits: register.size}];
 };
 
 const generateRegisterBundle = register => {
   const fields = getRegisterFields(register).map((field, idx) => {
     if (register.access) {
       var direction = '';
-      switch (access) {
+      switch (register.access) {
       case 'read-write':
       case 'write-only':
       case 'read-writeOnce':

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -17,24 +17,22 @@ const getRegisterFields = register => {
 };
 
 const generateRegisterBundle = (access, register) => {
-  const direction = (access => {
-    switch (access) {
-    case 'read-write':
-    case 'read-writeOnce':
-    case 'write-only':
-    case 'writeOnce':
-      return 'Output';
-    case 'read-only':
-      return 'Input';
-    case undefined:
-      return undefined;
-    default:
-      throw new Error(`invalid access field value: ${access}`);
-    }
-  })(access);
-
   const fields = getRegisterFields(register).map((field, idx) => {
-    if (direction) {
+    const fieldAccess = field.access || access;
+    if (fieldAccess) {
+      const direction = (access => {
+        switch (access) {
+        case 'read-write':
+        case 'read-writeOnce':
+        case 'write-only':
+        case 'writeOnce':
+          return 'Output';
+        case 'read-only':
+          return 'Input';
+        default:
+          throw new Error(`invalid access field value: ${access}`);
+        }
+      })(fieldAccess);
       return `val ${getScalaBundleRegFieldName(field, idx)} = ${direction}(UInt(${field.bits}.W))`;
     } else {
       return `// PAD ${field.bits}`;
@@ -90,18 +88,34 @@ const generateRegisterField = (field, scalaRegisterName, access) => {
   }
 };
 
+const generateRegisterFieldReset = (field, scalaRegisterName, access) => {
+  const resetValue = "0.U";
+  return access ? `${scalaRegisterName} := ${resetValue}` : `RegField(${field.bits})`;
+};
+
 const generateRegister = (access, register, scalaRegMapBundleName) => {
   const scalaRegBundleName = `${scalaRegMapBundleName}.${register.name}`;
 
   const regFieldSeqElements = getRegisterFields(register).map((field, idx) => {
     const scalaBundleField = getScalaBundleRegFieldName(field, idx);
-    return generateRegisterField(field, `${scalaRegBundleName}.${scalaBundleField}`, access);
+    return generateRegisterField(field, `${scalaRegBundleName}.${scalaBundleField}`, field.access || access);
   });
 
   const registerDesc = register.description ? `Some("${register.description}")` : 'None';
 
   return `${register.addressOffset} -> RegFieldGroup("${register.name}", ${registerDesc}, Seq(
 ${indent(2)(regFieldSeqElements.join(',\n'))}))`;
+};
+
+const generateRegisterReset = (access, register, scalaRegMapBundleName) => {
+  const scalaRegBundleName = `${scalaRegMapBundleName}.${register.name}`;
+
+  const regFieldSeqElements = getRegisterFields(register).map((field, idx) => {
+    const scalaBundleField = getScalaBundleRegFieldName(field, idx);
+    return generateRegisterFieldReset(field, `${scalaRegBundleName}.${scalaBundleField}`, field.access || access);
+  });
+
+  return regFieldSeqElements.join('\n');
 };
 
 const getAddressBlockNames = addressBlock => {
@@ -112,6 +126,7 @@ const getAddressBlockNames = addressBlock => {
     userParamsObject: `${regRouterName}User`,
     ioBundle: `${addressBlock.name}AddressBlockBundle`,
     regMapRegister: 'register',
+    regMapResetWire: 'resetValue',
     tlRegMap: `${addressBlock.name}TLRegMap`,
     axi4RegMap: `${addressBlock.name}AXI4RegMap`
   };
@@ -122,6 +137,10 @@ const generateBodyBase = (addressBlock, packageName, deviceNameString, compatStr
 
   const registerMapElements = addressBlock.registers.map((register) => {
     return generateRegister(register.access || addressBlock.access, register, names.regMapRegister);
+  });
+
+  const resetElements = addressBlock.registers.map((register) => {
+    return generateRegisterReset(register.access || addressBlock.access, register, names.regMapResetWire);
   });
 
   const bundleDefs = generateAddressBlockBundles(addressBlock);
@@ -158,8 +177,12 @@ abstract class ${names.regRouter}(busWidthBytes: Int, baseAddress: Long)(implici
 
   lazy val module = new LazyModuleImp(this) {
     val portValue = ioNode.makeIO()
-    val ${names.regMapRegister} = RegInit(0.U.asTypeOf(portValue.cloneType.asOutput))
+    val ${names.regMapResetWire} = Wire(portValue.cloneType.asOutput)
+${indent(4)(resetElements.join('\n'))}
+
+    val ${names.regMapRegister} = RegInit(resetValue)
     portValue <> ${names.regMapRegister}
+
     val mapping = Seq(
 ${indent(6)(registerMapElements.join(',\n'))})
     regmap(mapping:_*)

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -16,23 +16,25 @@ const getRegisterFields = register => {
   return register.fields || [{bits: register.size}];
 };
 
-const generateRegisterBundle = register => {
-  const fields = getRegisterFields(register).map((field, idx) => {
-    if (register.access) {
-      var direction = '';
-      switch (register.access) {
+const generateRegisterBundle = (access, register) => {
+  const direction = (access => {
+    switch (access) {
       case 'read-write':
       case 'write-only':
       case 'read-writeOnce':
       case 'writeOnce':
-        direction = 'Output';
-        break;
+        return 'Output';
       case 'read-only':
-        direction = 'Input';
-        break;
+        return 'Input';
+      case undefined:
+        return undefined;
       default:
-        throw new Error(`invalid access field value: ${field.access}`);
-      }
+        throw new Error(`invalid access field value: ${access}`);
+    }
+  })(access);
+
+  const fields = getRegisterFields(register).map((field, idx) => {
+    if (direction) {
       return `val ${getScalaBundleRegFieldName(field, idx)} = ${direction}(UInt(${field.bits}.W))`;
     } else {
       return `// PAD ${field.bits}`;
@@ -51,7 +53,7 @@ const getScalaAddressBlockBundleName = (addressBlock) => {
 
 const generateAddressBlockBundles = addressBlock => {
   const registerBundles = addressBlock.registers.map((register) => {
-    return generateRegisterBundle(register);
+    return generateRegisterBundle(register.access || addressBlock.access, register);
   });
 
   const bundleFields = addressBlock.registers.map((register) => {
@@ -93,12 +95,12 @@ const generateRegisterField = (field, scalaRegisterName, access) => {
   }
 };
 
-const generateRegister = (register, scalaRegMapBundleName) => {
+const generateRegister = (access, register, scalaRegMapBundleName) => {
   const scalaRegBundleName = `${scalaRegMapBundleName}.${register.name}`;
 
-  const regFieldSeqElements = getRegisterFields(register).fields.map((field, idx) => {
+  const regFieldSeqElements = getRegisterFields(register).map((field, idx) => {
     const scalaBundleField = getScalaBundleRegFieldName(field, idx);
-    return generateRegisterField(field, `${scalaRegBundleName}.${scalaBundleField}`, register.access);
+    return generateRegisterField(field, `${scalaRegBundleName}.${scalaBundleField}`, access);
   });
 
   const registerDesc = register.description ? `Some("${register.description}")` : 'None';
@@ -111,7 +113,7 @@ const generateBody = (addressBlock, packageName) => {
   const scalaRegMapBundleName = 'register';
 
   const registerMapElements = addressBlock.registers.map((register) => {
-    return generateRegister(register, scalaRegMapBundleName);
+    return generateRegister(register.access || addressBlock.access, register, scalaRegMapBundleName);
   });
 
   const bundleDefs = generateAddressBlockBundles(addressBlock);

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -15,7 +15,21 @@ const getScalaRegisterBundleName = (register) => {
 const generateRegisterBundle = register => {
   const fields = register.fields.map((field, idx) => {
     if (field.access) {
-      return `val ${getScalaBundleRegFieldName(field, idx)} = UInt(${field.bits}.W)`;
+      var direction = '';
+      switch (field.access) {
+      case 'read-write':
+      case 'write-only':
+      case 'read-writeOnce':
+      case 'writeOnce':
+        direction = 'Output';
+        break;
+      case 'read-only':
+        direction = 'Input';
+        break;
+      default:
+        throw new Error(`invalid access field value: ${field.access}`);
+      }
+      return `val ${getScalaBundleRegFieldName(field, idx)} = ${direction}(UInt(${field.bits}.W))`;
     } else {
       return `// PAD ${field.bits}`;
     }
@@ -131,11 +145,12 @@ abstract class ${addressBlock.name}RegRouter(busWidthBytes: Int, baseAddress: Lo
   }
 
   lazy val module = new LazyModuleImp(this) {
-    val portValue = port.getWrappedValue
-    val ${scalaRegMapBundleName} = RegInit(0.U.asTypeOf(portValue))
+    val portValue = ioNode.makeIO()
+    val ${scalaRegMapBundleName} = RegInit(0.U.asTypeOf(portValue.cloneType.asOutput))
     portValue <> ${scalaRegMapBundleName}
-    regmap(
+    val mapping = Seq(
 ${indent(6)(registerMapElements.join(',\n'))})
+    regmap(mapping:_*)
   }
 }
 

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -46,11 +46,6 @@ ${indent(2)(fields.join('\n'))}
 }`;
 };
 
-
-const getScalaAddressBlockBundleName = (addressBlock) => {
-  return `${addressBlock.name}AddressBlockBundle`;
-};
-
 const generateAddressBlockBundles = addressBlock => {
   const registerBundles = addressBlock.registers.map((register) => {
     return generateRegisterBundle(register.access || addressBlock.access, register);
@@ -60,9 +55,11 @@ const generateAddressBlockBundles = addressBlock => {
     return `val ${register.name} = new ${getScalaRegisterBundleName(register)}()`;
   });
 
+  const names = getAddressBlockNames(addressBlock);
+
   return `${registerBundles.join('\n\n')}
 
-class ${getScalaAddressBlockBundleName(addressBlock)} extends Bundle {
+class ${names.ioBundle} extends Bundle {
 ${indent(2)(bundleFields.join('\n'))}
 }`;
 };
@@ -107,16 +104,25 @@ const generateRegister = (access, register, scalaRegMapBundleName) => {
 ${indent(2)(regFieldSeqElements.join(',\n'))}))`;
 };
 
-const generateBody = (addressBlock, packageName, compatString) => {
-  const scalaRegMapBundleName = 'register';
+const getAddressBlockNames = addressBlock => {
+  return {
+    regRouter: `${addressBlock.name}RegRouter`,
+    defaultParamsObject: `${this.regRouter}Defaults`,
+    ioBundle: `${addressBlock.name}AddressBlockBundle`,
+    regMapRegister: 'register',
+    tlRegMap: `${addressBlock.name}TLRegMap`,
+    axi4RegMap: `${addressBlock.name}AXI4RegMap`
+  };
+};
+
+const generateBodyBase = (addressBlock, packageName, compatString) => {
+  const names = getAddressBlockNames(addressBlock);
 
   const registerMapElements = addressBlock.registers.map((register) => {
-    return generateRegister(register.access || addressBlock.access, register, scalaRegMapBundleName);
+    return generateRegister(register.access || addressBlock.access, register, names.regMapRegister);
   });
 
   const bundleDefs = generateAddressBlockBundles(addressBlock);
-
-  const className = `${addressBlock.name}RegRouter`
 
   return `// Generated Code
 // Please DO NOT EDIT
@@ -134,38 +140,37 @@ import freechips.rocketchip.amba.axi4.HasAXI4ControlRegMap
 
 ${bundleDefs}
 
-${className}Defaults {
+object ${names.defaultParamsObject} {
   def name: String = "${addressBlock.name}"
-  def compat: Seq[String] = Seq("${compatString}")
+  def compat: Seq[String] = Seq(${compatString})
 }
 
-abstract class ${className}(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
+abstract class ${names.regRouter}(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
   extends IORegisterRouter(
     RegisterRouterParams(
-      name = ${className}.name,
-      compat = ${className}.compat,
+      name = ${names.defaultParamsObject}.name,
+      compat = ${names.defaultParamsObject}.compat,
       base = baseAddress,
       beatBytes = busWidthBytes),
-    new ${getScalaAddressBlockBundleName(addressBlock)}) {
+    new ${names.ioBundle}) {
 
   lazy val module = new LazyModuleImp(this) {
     val portValue = ioNode.makeIO()
-    val ${scalaRegMapBundleName} = RegInit(0.U.asTypeOf(portValue.cloneType.asOutput))
-    portValue <> ${scalaRegMapBundleName}
+    val ${names.regMapRegister} = RegInit(0.U.asTypeOf(portValue.cloneType.asOutput))
+    portValue <> ${names.regMapRegister}
     val mapping = Seq(
 ${indent(6)(registerMapElements.join(',\n'))})
     regmap(mapping:_*)
   }
 }
 
-class ${addressBlock.name}TLRegMap(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
-  extends ${addressBlock.name}RegRouter(busWidthBytes, baseAddress) with HasTLControlRegMap
+class ${names.tlRegMap}(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
+  extends ${names.regRouter}(busWidthBytes, baseAddress) with HasTLControlRegMap
 
-class ${addressBlock.name}AXI4RegMap(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
-  extends ${addressBlock.name}RegRouter(busWidthBytes, baseAddress) with HasAXI4ControlRegMap
+class ${names.axi4RegMap}AXI4RegMap(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
+  extends ${names.regRouter}(busWidthBytes, baseAddress) with HasAXI4ControlRegMap
 `;
 };
-
 
 const exportRegmap = comp => {
   const memoryMaps = comp.memoryMaps || [];
@@ -178,7 +183,8 @@ const exportRegmap = comp => {
     let memoryMapResult = {};
     addressBlocks.forEach((addressBlock) => {
       const packageName = `${packageNameBase}.${memoryMap.name}.${addressBlock.name}`;
-      memoryMapResult[addressBlock.name] = generateBody(addressBlock, packageName);
+      const compatString = `"${comp.vendor},${comp.name}-${comp.version}"`;
+      memoryMapResult[addressBlock.name] = generateBodyBase(addressBlock, packageName, compatString);
     });
 
     result[memoryMap.name] = memoryMapResult;

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -19,17 +19,17 @@ const getRegisterFields = register => {
 const generateRegisterBundle = (access, register) => {
   const direction = (access => {
     switch (access) {
-      case 'read-write':
-      case 'write-only':
-      case 'read-writeOnce':
-      case 'writeOnce':
-        return 'Output';
-      case 'read-only':
-        return 'Input';
-      case undefined:
-        return undefined;
-      default:
-        throw new Error(`invalid access field value: ${access}`);
+    case 'read-write':
+    case 'write-only':
+    case 'read-writeOnce':
+    case 'writeOnce':
+      return 'Output';
+    case 'read-only':
+      return 'Input';
+    case undefined:
+      return undefined;
+    default:
+      throw new Error(`invalid access field value: ${access}`);
     }
   })(access);
 

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -67,20 +67,20 @@ ${indent(2)(bundleFields.join('\n'))}
 const generateRegisterField = (field, scalaRegisterName, access) => {
   if (access) {
     const regFieldDesc = field.name || field.desc ?
-      `, RegFieldDesc(${field.name ? `"${field.name}"` : '""'}, ${field.desc ? `"${field.desc}"` : '""'}))` :
-      ')';
+      `RegFieldDesc(${field.name ? `"${field.name}"` : '""'}, ${field.desc ? `"${field.desc}"` : '""'})` :
+      '';
 
     switch (access) {
     case 'read-write':
-      return `RegField(${field.bits}, ${scalaRegisterName}${regFieldDesc}`;
+      return `RegField(${field.bits}, ${scalaRegisterName}, ${regFieldDesc})`;
     case 'read-only':
-      return `RegField.r(${field.bits}, ${scalaRegisterName}${regFieldDesc}`;
+      return `RegField.r(${field.bits}, ${scalaRegisterName}, ${regFieldDesc})`;
     case 'write-only':
-      return `RegField.w(${field.bits}, ${scalaRegisterName}${regFieldDesc}`;
+      return `RegField.w(${field.bits}, ${scalaRegisterName}, ${regFieldDesc})`;
     case 'read-writeOnce':
-      return `RegField(${field.bits}, ${scalaRegisterName}, regFieldWriteOnceFn(${scalaRegisterName})${regFieldDesc}`;
+      return `RegField(${field.bits}, ${scalaRegisterName}, regFieldWriteOnceFn(${scalaRegisterName}), ${regFieldDesc})`;
     case 'writeOnce':
-      return `RegField(${field.bits}, (), regFieldWriteOnceFn(${scalaRegisterName})${regFieldDesc}`;
+      return `RegField(${field.bits}, (), regFieldWriteOnceFn(${scalaRegisterName}), ${regFieldDesc})`;
     default:
       throw new Error(`invalid access field value: ${access}`);
     }

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -14,7 +14,11 @@ const getScalaRegisterBundleName = (register) => {
 
 const generateRegisterBundle = register => {
   const fields = register.fields.map((field, idx) => {
-    return `val ${getScalaBundleRegFieldName(field, idx)} = UInt(${field.bits}.W)`;
+    if (field.access) {
+      return `val ${getScalaBundleRegFieldName(field, idx)} = UInt(${field.bits}.W)`;
+    } else {
+      return `// PAD ${field.bits}`;
+    }
   });
 
   return `class ${getScalaRegisterBundleName(register)} extends Bundle {
@@ -58,11 +62,11 @@ const generateRegisterField = field => scalaRegisterName => {
     case 'read-only':
       return `RegField.r(${field.bits}, ${scalaRegisterName}${regFieldDesc}`;
     case 'write-only':
-      return `RegField.w(${field.bits}, ${scalaRegisterName}${regFieldDesc})`;
+      return `RegField.w(${field.bits}, ${scalaRegisterName}${regFieldDesc}`;
     case 'read-writeOnce':
       return `RegField(${field.bits}, ${scalaRegisterName}, regFieldWriteOnceFn(${scalaRegisterName})${regFieldDesc}`;
     case 'writeOnce':
-      return `RegField(${field.bits}, Unit, regFieldWriteOnceFn(${scalaRegisterName})${regFieldDesc}`;
+      return `RegField(${field.bits}, (), regFieldWriteOnceFn(${scalaRegisterName})${regFieldDesc}`;
     default:
       throw new Error(`invalid access field value: ${field.access}`);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,8 @@
 
 const exportScalaBase = require('./export-scala-base.js');
 const exportScalaUser = require('./export-scala-user.js');
+const exportScalaRegMap = require('./export-scala-regmap.js');
 
 exports.exportScalaBase = exportScalaBase;
 exports.exportScalaUser = exportScalaUser;
-  
+exports.exportScalaRegMap = exportScalaRegMap;


### PR DESCRIPTION
adds a `duh-export-scala` script that can take a `duh` document and outputs scala files containing `RegisterRouter`s corresponding to the `memoryMaps` defined in the `duh` document.

example:
memMap:
```javascript
csrMemMap: {
  name: 'CSR',
  addressBlocks: [{
    name: 'csrAddressBlock',
    baseAddress: 0,
    range: 1024, width: 32,
    usage: 'register',
    volatile: false,
    registers: [{
      name: 'ODATA',
      addressOffset: 0, size: 64,
      displayName: 'Output Data Register',
      fields: [
        {name: 'data1', bits: 32, access: 'read-write', desc: 'this is the data1 field of ODATA'},
        {name: 'data2', bits: 32, access: 'write-only', desc: 'this is the data2 field of ODATA'},
      ]
    }, {
      name: 'OENABLE', addressOffset: 8, size: 32,
      displayName: 'Data direction',
      description: 'determines whether the pin is an input or an output. If the data direction bit is a 1, then the pin is an input',
      fields: [
        {name: 'foo', bits: 32, access: 'read-writeOnce', desc: 'this is the foo field of OENABLE'},
        {name: 'pad', bits: 32},
        {name: 'bar', bits: 32, access: 'writeOnce', desc: 'this is the bar field of OENABLE'},
      ]
    }, {
      name: 'IDATA', addressOffset: 12, size: 32,
      displayName: 'Input data',
      description: 'read the port pins',
      fields: [{name: 'data', bits: 32, access: 'read-only', desc: 'this is the data field of IDATA'}]
    }]
  }]
}
```

user scala:
```scala
package sifive.blocks.pio.CSR.csrAddressBlock

import chisel3._

object csrAddressBlockRegRouterUser {
  def deviceTreeName: String = csrAddressBlockRegRouterBase.deviceTreeName
  def deviceTreeCompat: Seq[String] = csrAddressBlockRegRouterBase.deviceTreeCompat

  object resetValues {
    object ODATA {
      def data: UInt =
        csrAddressBlockRegRouterBase.resetValues.ODATA.data
    }

    object OENABLE {
      def data: UInt =
        csrAddressBlockRegRouterBase.resetValues.OENABLE.data
    }

    object IDATA {
      def data: UInt =
        csrAddressBlockRegRouterBase.resetValues.IDATA.data
    }
  }
}
```

base scala:
```scala
// Generated Code
// Please DO NOT EDIT


package sifive.blocks.pio.CSR.csrAddressBlock

import chisel3._

import freechips.rocketchip.config.Parameters
import freechips.rocketchip.diplomacy.LazyModuleImp
import freechips.rocketchip.regmapper._
import freechips.rocketchip.tilelink.HasTLControlRegMap
import freechips.rocketchip.amba.axi4.HasAXI4ControlRegMap

class ODATARegisterBundle extends Bundle {
  val data = Output(UInt(32.W))
}

class OENABLERegisterBundle extends Bundle {
  val data = Output(UInt(32.W))
}

class IDATARegisterBundle extends Bundle {
  val data = Input(UInt(32.W))
}

class csrAddressBlockAddressBlockBundle extends Bundle {
  val ODATA = new ODATARegisterBundle()
  val OENABLE = new OENABLERegisterBundle()
  val IDATA = new IDATARegisterBundle()
}

object csrAddressBlockRegRouterBase {
  def deviceTreeName: String = "pio-csrAddressBlock"
  def deviceTreeCompat: Seq[String] = Seq("sifive,pio-0.1.0")

  object resetValues {
    object ODATA {
      def data: UInt = 0.U
    }

    object OENABLE {
      def data: UInt = 0.U
    }

    object IDATA {
      def data: UInt = 0.U
    }
  }
}

abstract class csrAddressBlockRegRouter(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
  extends IORegisterRouter(
    RegisterRouterParams(
      name = csrAddressBlockRegRouterUser.deviceTreeName,
      compat = csrAddressBlockRegRouterUser.deviceTreeCompat,
      base = baseAddress,
      beatBytes = busWidthBytes),
    new csrAddressBlockAddressBlockBundle) {

  lazy val module = new LazyModuleImp(this) {
    val portValue = ioNode.makeIO()
    val resetValue = Wire(portValue.cloneType.asOutput)
    resetValue.ODATA.data := csrAddressBlockRegRouterUser.resetValues.ODATA.data
    resetValue.OENABLE.data := csrAddressBlockRegRouterUser.resetValues.OENABLE.data
    resetValue.IDATA.data := csrAddressBlockRegRouterUser.resetValues.IDATA.data

    val register = RegInit(resetValue)
    portValue <> register

    val mapping = Seq(
      0 -> RegFieldGroup("ODATA", None, Seq(
        RegField(32, resetValue.ODATA.data, RegFieldDesc("data", "")))),
      4 -> RegFieldGroup("OENABLE", Some("determines whether the pin is an input or an output. If the data direction bit is a 1, then the pin is an input"), Seq(
        RegField(32, resetValue.OENABLE.data, RegFieldDesc("data", "")))),
      8 -> RegFieldGroup("IDATA", Some("read the port pins"), Seq(
        RegField.r(32, resetValue.IDATA.data, RegFieldDesc("data", "")))))
    regmap(mapping:_*)
  }
}

class csrAddressBlockTLRegMap(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
  extends csrAddressBlockRegRouter(busWidthBytes, baseAddress) with HasTLControlRegMap

class csrAddressBlockAXI4RegMapAXI4RegMap(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
  extends csrAddressBlockRegRouter(busWidthBytes, baseAddress) with HasAXI4ControlRegMap
```