### PR TITLE
emit 'exists' ResourceBinding in base scala

### DIFF
--- a/lib/export-scala-base.js
+++ b/lib/export-scala-base.js
@@ -379,8 +379,11 @@ class N${comp.name}TopLogicalTreeNode(component: N${comp.name}TopBase) extends L
 
 class N${comp.name}TopBase(val c: N${comp.name}TopParams)(implicit p: Parameters)
  extends SimpleLazyModule
+ with BindingScope
  with HasLogicalTreeNode {
   val imp = LazyModule(new L${comp.name}(c.blackbox))
+
+  ResourceBinding { Resource(imp.device, "exists").bind(ResourceString("yes")) }
 
   def userOM: Product with Serializable = Nil
 


### PR DESCRIPTION
adds this line https://github.com/chipsalliance/rocket-chip/blob/master/src/main/scala/diplomacy/Resources.scala#L89 to the base scala to prevent an `IllegalArgumentException` from being thrown when elaborating the Object Model.