### PR TITLE
APB: fix AddressSet mask

### DIFF
--- a/lib/apb-scala.js
+++ b/lib/apb-scala.js
@@ -16,7 +16,7 @@ const slaveAdapterGen = comp => e => {
   return `APBSlaveNode(Seq(
     APBSlavePortParameters(
       slaves = Seq(APBSlaveParameters(
-        address = List(AddressSet(${params}.base, 0x${(Math.pow(2, addrWidth) - 1).toString(16)}L)),
+        address = List(AddressSet(${params}.base, ((1L << ${addrWidth}) - 1))),
         // resources
         // regionType
         executable = false,


### PR DESCRIPTION
fix emitted scala code for AHB slave node address set. Fixes bug where if the `PADDR` width was a parameter a `NaN` would be emitted.