### PR TITLE
add export-scala-monitor

### DIFF
--- a/bin/duh-export-monitor.js
+++ b/bin/duh-export-monitor.js
@@ -2,16 +2,9 @@
 'use strict';
 
 const path = require('path');
-const fs = require('fs-extra');
 const yargs = require('yargs');
-const scalametaParsers = require('scalameta-parsers');
-
-const duhCore = require('duh-core');
 
 const lib = require('../lib/index.js');
-const traverseSpec = require('../lib/traverse-spec');
-
-const parseSource = scalametaParsers.parseSource;
 
 const argv = yargs
   .option('output', {
@@ -29,43 +22,12 @@ const argv = yargs
   .help()
   .argv;
 
-const flow = argv => new Promise (resolve => {
-  const outputDir = argv.output;
-  if (argv.verbose) console.log('regmap');
-  duhCore.readDuh(argv)
-    .then(duhCore.expandAll)
-    .then(duh => {
-      const emittedRegMappers = lib.exportScalaMonitor(duh.component);
-      const writeFiles = (isBase) => traverseSpec({
-        leaf: (node, path) => {
-          const fileName = `${outputDir}/${path.join('/')}.scala`;
-          fs.pathExists(fileName).then(exists => {
-            if (!exists || isBase) {
-
-              fs.outputFile(fileName, node);
-
-              if (argv.validate) {
-                const ast = parseSource.call({}, node);
-                if (ast.error) {
-                  console.error(ast);
-                  throw new SyntaxError(ast.error);
-                }
-              }
-            }
-          });
-        }
-      });
-      writeFiles(true)(emittedRegMappers.base);
-      writeFiles(false)(emittedRegMappers.user);
-      resolve();
-    });
-});
-
 const main = argv => {
   const cwd = process.cwd();
   const folderName = path.basename(cwd);
   const fileName = argv._[0] || folderName + '.json5';
-  flow(Object.assign({filename: fileName}, argv));
+  if (argv.verbose) console.log('monitor');
+  lib.fileWriter(lib.exportScalaMonitor, Object.assign({filename: fileName}, argv));
 };
 
 main(argv);

--- a/bin/duh-export-monitor.js
+++ b/bin/duh-export-monitor.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const fs = require('fs-extra');
+const yargs = require('yargs');
+const scalametaParsers = require('scalameta-parsers');
+
+const duhCore = require('duh-core');
+
+const lib = require('../lib/index.js');
+const traverseSpec = require('../lib/traverse-spec');
+
+const parseSource = scalametaParsers.parseSource;
+
+const argv = yargs
+  .option('output', {
+    alias: 'o',
+    describe: 'output path for exported files',
+    default: 'component/src'
+  })
+  .option('validate', {
+    alias: 'val',
+    describe: 'validate output Scala',
+    default: false,
+    type: 'boolean'
+  })
+  .version()
+  .help()
+  .argv;
+
+const flow = argv => new Promise (resolve => {
+  const outputDir = argv.output;
+  if (argv.verbose) console.log('regmap');
+  duhCore.readDuh(argv)
+    .then(duhCore.expandAll)
+    .then(duh => {
+      const emittedRegMappers = lib.exportScalaMonitor(duh.component);
+      const writeFiles = (isBase) => traverseSpec({
+        leaf: (node, path) => {
+          const fileName = `${outputDir}/${path.join('/')}.scala`;
+          fs.pathExists(fileName).then(exists => {
+            if (!exists || isBase) {
+
+              fs.outputFile(fileName, node);
+
+              if (argv.validate) {
+                const ast = parseSource.call({}, node);
+                if (ast.error) {
+                  console.error(ast);
+                  throw new SyntaxError(ast.error);
+                }
+              }
+            }
+          });
+        }
+      });
+      writeFiles(true)(emittedRegMappers.base);
+      writeFiles(false)(emittedRegMappers.user);
+      resolve();
+    });
+});
+
+const main = argv => {
+  const cwd = process.cwd();
+  const folderName = path.basename(cwd);
+  const fileName = argv._[0] || folderName + '.json5';
+  flow(Object.assign({filename: fileName}, argv));
+};
+
+main(argv);
+/* eslint no-console: 0 */

--- a/bin/duh-export-regmap.js
+++ b/bin/duh-export-regmap.js
@@ -2,16 +2,9 @@
 'use strict';
 
 const path = require('path');
-const fs = require('fs-extra');
 const yargs = require('yargs');
-const scalametaParsers = require('scalameta-parsers');
-
-const duhCore = require('duh-core');
 
 const lib = require('../lib/index.js');
-const traverseSpec = require('../lib/traverse-spec.js');
-
-const parseSource = scalametaParsers.parseSource;
 
 const argv = yargs
   .option('output', {
@@ -29,43 +22,12 @@ const argv = yargs
   .help()
   .argv;
 
-const flow = argv => new Promise (resolve => {
-  const outputDir = argv.output;
-  if (argv.verbose) console.log('regmap');
-  duhCore.readDuh(argv)
-    .then(duhCore.expandAll)
-    .then(duh => {
-      const emittedRegMappers = lib.exportScalaRegMap(duh.component);
-      const writeFiles = (isBase) => traverseSpec({
-        leaf: (node, path) => {
-          const fileName = `${outputDir}/${path.join('/')}.scala`;
-          fs.pathExists(fileName).then(exists => {
-            if (!exists || isBase) {
-
-              fs.outputFile(fileName, node);
-
-              if (argv.validate) {
-                const ast = parseSource.call({}, node);
-                if (ast.error) {
-                  console.error(ast);
-                  throw new SyntaxError(ast.error);
-                }
-              }
-            }
-          });
-        }
-      });
-      writeFiles(true)(emittedRegMappers.base);
-      writeFiles(false)(emittedRegMappers.user);
-      resolve();
-    });
-});
-
 const main = argv => {
   const cwd = process.cwd();
   const folderName = path.basename(cwd);
   const fileName = argv._[0] || folderName + '.json5';
-  flow(Object.assign({filename: fileName}, argv));
+  if (argv.verbose) console.log('regmap');
+  lib.fileWriter(lib.exportScalaRegMap, Object.assign({filename: fileName}, argv));
 };
 
 main(argv);

--- a/lib/apb-scala.js
+++ b/lib/apb-scala.js
@@ -101,5 +101,16 @@ module.exports = {
     // wiring: () => () => ''
   },
   busDef: busDef,
-  memoryMapped: true
+  memoryMapped: true,
+  monitor: {
+    names: {
+      args: 'APBMonitorArgs',
+      baseMonitor: 'APBMonitorBase',
+      edgeParams: 'APBEdgeParameters',
+      bundle: 'APBBundle'
+    },
+    imports: [
+      'freechips.rocketchip.amba.axi4.{APBBundle, APBEdgeParameters, APBMonitorArgs, APBMonitorBase}'
+    ]
+  }
 };

--- a/lib/axi4-tl.js
+++ b/lib/axi4-tl.js
@@ -244,5 +244,16 @@ module.exports = {
     wiring: () => () => ''
   },
   busDef: busDef,
-  memoryMapped: true
+  memoryMapped: true,
+  monitor: {
+    names: {
+      args: 'AXI4MonitorArgs',
+      baseMonitor: 'AXI4MonitorBase',
+      edgeParams: 'AXI4EdgeParameters',
+      bundle: 'AXI4Bundle'
+    },
+    imports: [
+      'freechips.rocketchip.amba.axi4.{AXI4Bundle, AXI4EdgeParameters, AXI4MonitorArgs, AXI4MonitorBase}'
+    ]
+  }
 };

--- a/lib/chisel-utils.js
+++ b/lib/chisel-utils.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const indent = require('./indent.js');
+const paramSchema = require('./param-schema.js');
+
+const toChiselType = (width) => {
+  return (width === 1 ? 'Bool()' : 'UInt((' + width + ').W)');
+};
+
+const toChiselDirection = direction => {
+  const dirMap = {
+    'in': 'Input',
+    'out': 'Output',
+    'inout': 'Analog'
+  };
+
+  const chiselDir = dirMap[direction];
+
+  if (!chiselDir) {
+    throw new Error(`${direction} is an invalid chisel direction, must be one of ${Object.keys(dirMap)}`);
+  }
+
+  return chiselDir;
+};
+
+const generateCaseClass = ({className, fields}) => {
+  const params = fields.map((field) => {
+    if (field.defaultValue) {
+      return `${field.name}: ${field.type} = ${field.defaultValue}`;
+    } else {
+      return `${field.name}: ${field.type}`;
+    }
+  });
+  return `case class ${className}(
+${indent(2, ',')(params)}
+)`;
+};
+
+const generateChiselBundle = ({ports, className, paramsMap}) => {
+  const nameMap = {};
+  const body = ports.map(port => {
+    const direction = toChiselDirection(port.wire.direction);
+    const name = port.name;
+    const type = toChiselType(port.wire.width);
+    nameMap[port.name] = name;
+    return `val ${name} = ${direction}(${type})`;
+  });
+
+  const stringParams = Object.entries(paramsMap).map(([key, value]) => {
+    return `val ${key}: ${value}`;
+  });
+
+  const stringValue = `class ${className}(
+${indent(2, ',')(stringParams)}
+) extends Bundle {
+${indent(2)(body)}
+}`;
+
+  return stringValue;
+};
+
+const toChiselParam = ({type, value}) => {
+  const typeMap = {
+    'int': 'IntParam',
+    'double': 'DoubleParam',
+    'string': 'StringParam',
+    'raw': 'RawParam'
+  };
+
+  const chiselType = typeMap[type];
+
+  if (chiselType) {
+    return `${chiselType}(${value})`;
+  } else {
+    throw new Error(`${type} is an invalid chisel blackbox parameter type, must be one of ${Object.keys(typeMap)}`);
+  }
+};
+
+const generateBlackBoxModule = ({className, paramsMap, blackboxParamsMap, ioType, ioParamsMap, desiredName}) => {
+
+  const stringParams = Object.entries(paramsMap).map(([key, value]) => {
+    return `val ${key}: ${value}`;
+  });
+
+  const stringBlackBoxParams = Object.entries(blackboxParamsMap).map(([key, value]) => {
+    return `"${key}" -> ${value}`;
+  });
+
+  const stringIOParams = Object.entries(ioParamsMap).map(([key, value]) => {
+    return `${key} = ${value}`;
+  });
+  const stringValue = `class ${className}(
+${indent(2, ',')(stringParams)}
+) extends BlackBox(Map(
+${indent(2, ',')(stringBlackBoxParams)}
+)) {
+  val io = IO(new ${ioType}(
+${indent(4, ',')(stringIOParams)}
+  ))
+
+  override val desiredName = "${desiredName}"
+}`;
+
+  return stringValue;
+};
+
+module.exports = {
+  generateBlackBox: generateBlackBoxModule,
+  generateBundle: generateChiselBundle,
+  convertType: toChiselType,
+  convertDirection: toChiselDirection,
+  convertParam: toChiselParam,
+  generateCaseClass: generateCaseClass
+};

--- a/lib/chisel-utils.js
+++ b/lib/chisel-utils.js
@@ -2,11 +2,11 @@
 
 const indent = require('./indent.js');
 
-const toChiselType = (width) => {
+const convertType = (width) => {
   return (width === 1 ? 'Bool()' : 'UInt((' + width + ').W)');
 };
 
-const toChiselDirection = direction => {
+const convertDirection = direction => {
   const dirMap = {
     'in': 'Input',
     'out': 'Output',
@@ -35,12 +35,12 @@ ${indent(2, ',')(params)}
 )`;
 };
 
-const generateChiselBundle = ({ports, className, paramsMap}) => {
+const generateBundle = ({ports, className, paramsMap}) => {
   const nameMap = {};
   const body = ports.map(port => {
-    const direction = toChiselDirection(port.wire.direction);
+    const direction = convertDirection(port.wire.direction);
     const name = port.name;
-    const type = toChiselType(port.wire.width);
+    const type = convertType(port.wire.width);
     nameMap[port.name] = name;
     return `val ${name} = ${direction}(${type})`;
   });
@@ -58,7 +58,7 @@ ${indent(2)(body)}
   return stringValue;
 };
 
-const toChiselParam = ({type, value}) => {
+const convertParam = ({type, value}) => {
   const typeMap = {
     'int': 'IntParam',
     'double': 'DoubleParam',
@@ -75,7 +75,7 @@ const toChiselParam = ({type, value}) => {
   }
 };
 
-const generateBlackBoxModule = ({className, paramsMap, blackboxParamsMap, ioType, ioParamsMap, desiredName}) => {
+const generateBlackBox = ({className, paramsMap, blackboxParamsMap, ioType, ioParamsMap, desiredName}) => {
 
   const stringParams = Object.entries(paramsMap).map(([key, value]) => {
     return `val ${key}: ${value}`;
@@ -104,10 +104,10 @@ ${indent(4, ',')(stringIOParams)}
 };
 
 module.exports = {
-  generateBlackBox: generateBlackBoxModule,
-  generateBundle: generateChiselBundle,
-  convertType: toChiselType,
-  convertDirection: toChiselDirection,
-  convertParam: toChiselParam,
+  generateBlackBox: generateBlackBox,
+  generateBundle: generateBundle,
+  convertType: convertType,
+  convertDirection: convertDirection,
+  convertParam: convertParam,
   generateCaseClass: generateCaseClass
 };

--- a/lib/chisel-utils.js
+++ b/lib/chisel-utils.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const indent = require('./indent.js');
-const paramSchema = require('./param-schema.js');
 
 const toChiselType = (width) => {
   return (width === 1 ? 'Bool()' : 'UInt((' + width + ').W)');

--- a/lib/export-scala-base.js
+++ b/lib/export-scala-base.js
@@ -17,7 +17,7 @@ const flipString = require('./flip-string.js');
 const indent = require('./indent.js');
 const parts = require('./export-scala-parts.js');
 const bundler = require('./export-scala-bundle.js');
-const type = require('./scala-type.js');
+const chisel = require('./chisel-utils.js');
 const paramSchema = require('./param-schema.js');
 
 
@@ -59,13 +59,9 @@ const getBusName = path => flipString(
 
 const perPort = e => {
 
-  const dir = ({
-    'in': 'Input',
-    'out': 'Output',
-    'inout': 'Analog'
-  })[e.wire.direction];
+  const dir = chisel.convertDirection(e.wire.direction);
 
-  return `  val ${e.name} = ${dir}(${type(e.wire.width)})`;
+  return `  val ${e.name} = ${dir}(${chisel.convertType(e.wire.width)})`;
 };
 
 const perBusInterface = comp => e => {

--- a/lib/export-scala-channel.js
+++ b/lib/export-scala-channel.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const type = require('./scala-type.js');
+const chisel = require('./chisel-utils.js');
 
 const findPort = (comp, busDef) => {
   const aType = busDef.abstractionTypes.find(e => e.viewRef === 'RTLview');
@@ -13,7 +13,7 @@ const findPort = (comp, busDef) => {
 const masterWiringGen = comp => e =>
   `val ${e.name}Node = new Object { // channel master wiring
   def out(x: Int) = {
-    val y = IO(Decoupled(${type(findPort(comp, e).wire.width)}))
+    val y = IO(Decoupled(${chisel.convertType(findPort(comp, e).wire.width)}))
       y.suggestName("${e.name}")
       (y, Nil)
     }
@@ -23,7 +23,7 @@ const masterWiringGen = comp => e =>
 const slaveWiringGen = comp => e =>
   `val ${e.name}Node = new Object { // channel slave wiring
   def in(x: Int) = {
-    val y = IO(Flipped(Decoupled(${type(findPort(comp, e).wire.width)})))
+    val y = IO(Flipped(Decoupled(${chisel.convertType(findPort(comp, e).wire.width)})))
       y.suggestName("${e.name}")
       (y, Nil)
     }
@@ -49,7 +49,7 @@ const commonNodeGen = comp => {
 
 ${comp.busInterfaces
     .filter(e => e.busType.name === 'channel')
-    .map(e => `    val ${e.name}_queue = Module(new Queue(${type(findPort(comp, e).wire.width)}, 4))`)
+    .map(e => `    val ${e.name}_queue = Module(new Queue(${chisel.convertType(findPort(comp, e).wire.width)}, 4))`)
     .join('\n')
 }
 

--- a/lib/export-scala-monitor.js
+++ b/lib/export-scala-monitor.js
@@ -1,0 +1,253 @@
+'use strict';
+
+const paramSchema = require('./param-schema.js');
+const traverseSpec = require('../lib/traverse-spec');
+const flipString = require('../lib/flip-string');
+
+const indent = require('./indent');
+const get = require('lodash.get');
+const axi4 = require('./axi4-tl');
+const apb = require('./apb-scala');
+const chisel = require('./chisel-utils');
+
+
+const generators = {
+  'amba.com': {
+    AMBA4: {
+      AXI4: axi4,
+      AXI4Lite: axi4,
+      APB4: apb
+    }
+  }
+};
+
+const generateBlackBoxComponents = (component, names) => {
+  const paramsMap = {};
+  const blackboxParamsMap = {};
+  const blackboxIOParamsMap = {};
+  const paramFields = [];
+
+  // TODO only integer params supported
+  paramSchema.reduce({
+    leaf: (node, path) => {
+      const name = path.join('_');
+      paramsMap[name] = 'Int';
+      blackboxParamsMap[name] = `core.IntParam(${name})`;
+      blackboxIOParamsMap[name] = name;
+      const paramField = {
+        name: name,
+        type: 'Int'
+      };
+      if (node.default) {
+        paramField['defaultValue'] = node.default;
+      }
+      paramFields.push(paramField);
+    }
+  })(component.pSchema);
+
+  const blackboxParams = chisel.generateCaseClass({
+    className: `${component.name}Params`,
+    fields: paramFields
+  });
+
+  const blackboxIO = chisel.generateBundle({
+    ports: component.model.ports,
+    className: names.blackbox.io.name,
+    paramsMap: paramsMap
+  });
+
+  const blackboxModule = chisel.generateBlackBox({
+    className: names.blackbox.name,
+    paramsMap: paramsMap,
+    blackboxParamsMap: blackboxParamsMap,
+    ioType: names.blackbox.io.name,
+    ioParamsMap: blackboxIOParamsMap,
+    desiredName: component.name
+  });
+
+  return {
+    params: blackboxParams,
+    bundle: blackboxIO,
+    module: blackboxModule
+  };
+};
+
+const generateMonitor = (component, names, generator) => {
+  const bus = component.busInterfaces[0];
+  const monitorNames = names.monitor;
+  const generatorNames = generator.monitor.names;
+  const paramsNames = monitorNames.paramsMethod;
+  const connectNames = monitorNames.connectMethod;
+  const legalizeNames = monitorNames.legalizeMethod;
+
+  const blackboxArgs = {};
+  paramSchema.reduce({
+    leaf: (node, path) => {
+      const name = path.join('_');
+      blackboxArgs[name] = 'params.' + name;
+    }
+  })(component.pSchema);
+
+  const portMap = ((bus.abstractionTypes || []).find(b => b.viewRef === 'RTLview') || {}).portMaps || {};
+
+  const connects = [];
+  traverseSpec({
+    enter: (node, path) => {
+      const duhName = flipString((path.length === 1) ? path[0] : (path[0] + path[path.length - 1]));
+      const scalaName = path.join('.');
+
+      if (portMap[duhName]) {
+        connects.push(`blackbox.io.${portMap[duhName]} := ${connectNames.bundle}.${scalaName}`);
+      }
+    }
+  })(generator.busDef);
+
+  const blackboxArgsAssign = Object.entries(blackboxArgs).map(([key, value]) => {
+    return `${key} = ${value}`;
+  });
+
+  const blackboxComponents = generateBlackBoxComponents(component, names);
+
+  return {
+    base: {
+      imports: ['chisel3._', 'chisel3.core.Reset'].concat(generator.monitor.imports),
+      body: `${blackboxComponents.params}
+
+${blackboxComponents.bundle}
+
+${blackboxComponents.module}
+
+abstract class ${monitorNames.baseName}(${monitorNames.args}: ${generatorNames.args}) extends ${generatorNames.baseMonitor}(${monitorNames.args}) {
+  def ${paramsNames.name}(${paramsNames.edgeParams}: ${generatorNames.edgeParams}): ${component.name}Params
+
+  def ${connectNames.name}(
+    ${connectNames.blackbox}: ${names.blackbox.name},
+    ${connectNames.bundle}: ${generatorNames.bundle},
+    ${connectNames.edgeParams}: ${generatorNames.edgeParams},
+    ${connectNames.reset}: Reset): Unit = {
+${indent(4)(connects)}
+  }
+
+  def ${legalizeNames.name}(
+    ${legalizeNames.bundle}: ${generatorNames.bundle},
+    ${legalizeNames.edgeParams}: ${generatorNames.edgeParams},
+    ${legalizeNames.reset}: Reset): Unit = {
+    val params = ${paramsNames.name}(${legalizeNames.edgeParams})
+    val blackbox = Module(new ${names.blackbox.name}(
+${indent(6, ',')(blackboxArgsAssign)}
+    ))
+    ${names.monitor.connectMethod.name}(blackbox, ${legalizeNames.bundle}, ${legalizeNames.edgeParams}, ${legalizeNames.reset})
+  }
+}`
+    },
+    user: {
+      imports: ['chisel3._', 'chisel3.core.Reset'].concat(generator.monitor.imports),
+      body: `class ${monitorNames.userName}(${names.monitor.args}: ${generatorNames.args}) extends ${names.monitor.baseName}(${names.monitor.args}) {
+  // IMPLEMENT THIS METHOD: convert the input parameters to blackbox parameters
+  def ${paramsNames.name}(${paramsNames.edgeParams}: ${generatorNames.edgeParams}): ${component.name}Params = {
+  }
+
+  // if you need to override the default connnection method: uncomment and implement this method
+  /*
+  override def ${connectNames.name}(
+    ${connectNames.blackbox}: ${names.blackbox.name},
+    ${connectNames.bundle}: ${generatorNames.bundle},
+    ${connectNames.edgeParams}: ${generatorNames.edgeParams},
+    ${connectNames.reset}: Reset): Unit = {
+  }
+  */
+}`
+    }
+  };
+};
+
+const getNames = comp => {
+  return {
+    blackbox: {
+      name: `${comp.name}BlackBox`,
+      params: {
+        name: `${comp.name}Params`
+      },
+      io: {
+        name: `${comp.name}BlackBoxIO`
+      }
+    },
+    monitor: {
+      baseName: `${comp.name}MonitorBase`,
+      userName: `${comp.name}Monitor`,
+      args: 'params',
+      paramsMethod: {
+        name: 'getBlackBoxParams',
+        edgeParams: 'edgeParams'
+      },
+      connectMethod: {
+        name: 'connectBlackBoxPorts',
+        edgeParams: 'edgeParams',
+        bundle: 'bundle',
+        blackbox: 'blackbox',
+        reset: 'reset'
+      },
+      legalizeMethod: {
+        name: 'legalize', // official rocket-chip name, do not change
+        edgeParams: 'edgeParams',
+        bundle: 'bundle',
+        reset: 'reset'
+      }
+    }
+  };
+};
+
+const getGenerator = component => {
+  if (component.busInterfaces.length !== 1 || component.busInterfaces[0].interfaceMode !== 'monitor') {
+    throw Error('duh component must have exactly one bus interface in monitor mode to generate a scala monitor');
+  }
+
+  const bus = component.busInterfaces[0];
+  const busPath = [bus.busType.vendor, bus.busType.library, bus.busType.name];
+  const generator = get(generators, busPath);
+
+  if (!(generator && generator.monitor)) {
+    throw new Error(`not a supported bus interface: ${busPath.join('.')}`);
+  }
+
+  return generator;
+};
+
+const exportMonitor = comp => {
+  const names = getNames(comp);
+  const generator = getGenerator(comp);
+  const monitor = generateMonitor(comp, names, generator);
+
+  const extraBaseImports = monitor.base.imports.map(i => {
+    return `import ${i}`;
+  });
+  const extraUserImports = monitor.user.imports.map(i => {
+    return `import ${i}`;
+  });
+
+  const base = `// Generated Code
+// Please DO NOT EDIT
+package ${comp.vendor}.${comp.library}.${comp.name}
+
+${extraBaseImports.join('\n')}
+
+${monitor.base.body}
+`;
+
+  const user = `package ${comp.vendor}.${comp.library}.${comp.name}
+
+${extraUserImports.join('\n')}
+
+${monitor.user.body}
+`;
+  const result = {
+    base: {},
+    user: {}
+  };
+
+  result.base[`${comp.name}-base`] = base;
+  result.user[comp.name] = user;
+  return result;
+};
+
+module.exports = exportMonitor;

--- a/lib/file-writer.js
+++ b/lib/file-writer.js
@@ -8,12 +8,28 @@ const duhCore = require('duh-core');
 const traverseSpec = require('./traverse-spec');
 const parseSource = scalametaParsers.parseSource;
 
+/**
+ * writes the output of a scala emitter to files
+ *
+ * Takes an emitter function that turns a duh component into scala source code.
+ * The emitter should return an object with fields 'base' and 'user' that have
+ * object values. The base and user objects source code trees where the leaves
+ * are the string contnents of the file and the path to the leaves are the file
+ * paths. The files specified by the base files alway be written, overriding
+ * any existing files. The user files will only be written if those files do
+ * not already exist. The argv.output specifies the root directory of the
+ * emitted files. If argv.validate is set then the output scala code will be
+ * checked for syntax errors.
+ *
+ * @param {Function} emitter emitter that emits scala code
+ * @param {Object}   argv    object containing options
+ */
 module.exports = (emitter, argv) => new Promise (resolve => {
   const outputDir = argv.output;
   duhCore.readDuh(argv)
     .then(duhCore.expandAll)
     .then(duh => {
-      const emittedRegMappers = emitter(duh.component);
+      const emittedContent = emitter(duh.component);
       const writeFiles = (isBase) => traverseSpec({
         leaf: (node, path) => {
           const fileName = `${outputDir}/${path.join('/')}.scala`;
@@ -33,8 +49,8 @@ module.exports = (emitter, argv) => new Promise (resolve => {
           });
         }
       });
-      writeFiles(true)(emittedRegMappers.base);
-      writeFiles(false)(emittedRegMappers.user);
+      writeFiles(true)(emittedContent.base);
+      writeFiles(false)(emittedContent.user);
       resolve();
     });
 });

--- a/lib/file-writer.js
+++ b/lib/file-writer.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const fs = require('fs-extra');
+const scalametaParsers = require('scalameta-parsers');
+
+const duhCore = require('duh-core');
+
+const traverseSpec = require('../lib/traverse-spec');
+const parseSource = scalametaParsers.parseSource;
+
+module.exports = (emitter, argv) => new Promise (resolve => {
+  const outputDir = argv.output;
+  duhCore.readDuh(argv)
+    .then(duhCore.expandAll)
+    .then(duh => {
+      const emittedRegMappers = emitter(duh.component);
+      const writeFiles = (isBase) => traverseSpec({
+        leaf: (node, path) => {
+          const fileName = `${outputDir}/${path.join('/')}.scala`;
+          fs.pathExists(fileName).then(exists => {
+            if (!exists || isBase) {
+
+              fs.outputFile(fileName, node);
+
+              if (argv.validate) {
+                const ast = parseSource.call({}, node);
+                if (ast.error) {
+                  console.error(ast);
+                  throw new SyntaxError(ast.error);
+                }
+              }
+            }
+          });
+        }
+      });
+      writeFiles(true)(emittedRegMappers.base);
+      writeFiles(false)(emittedRegMappers.user);
+      resolve();
+    });
+});

--- a/lib/file-writer.js
+++ b/lib/file-writer.js
@@ -5,7 +5,7 @@ const scalametaParsers = require('scalameta-parsers');
 
 const duhCore = require('duh-core');
 
-const traverseSpec = require('../lib/traverse-spec');
+const traverseSpec = require('./traverse-spec');
 const parseSource = scalametaParsers.parseSource;
 
 module.exports = (emitter, argv) => new Promise (resolve => {
@@ -38,3 +38,4 @@ module.exports = (emitter, argv) => new Promise (resolve => {
       resolve();
     });
 });
+/* eslint no-console: 0 */

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,12 @@
 'use strict';
 
+const fileWriter = require('./file-writer.js');
 const exportScalaBase = require('./export-scala-base.js');
 const exportScalaUser = require('./export-scala-user.js');
 const exportScalaRegMap = require('./export-scala-regmap.js');
 const exportScalaMonitor = require('./export-scala-monitor.js');
 
+exports.fileWriter = fileWriter;
 exports.exportScalaBase = exportScalaBase;
 exports.exportScalaUser = exportScalaUser;
 exports.exportScalaRegMap = exportScalaRegMap;

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,9 @@
 const exportScalaBase = require('./export-scala-base.js');
 const exportScalaUser = require('./export-scala-user.js');
 const exportScalaRegMap = require('./export-scala-regmap.js');
+const exportScalaMonitor = require('./export-scala-monitor.js');
 
 exports.exportScalaBase = exportScalaBase;
 exports.exportScalaUser = exportScalaUser;
 exports.exportScalaRegMap = exportScalaRegMap;
+exports.exportScalaMonitor = exportScalaMonitor;

--- a/lib/scala-type.js
+++ b/lib/scala-type.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = p => (p === 1 ? 'Bool()' : 'UInt((' + p + ').W)');


### PR DESCRIPTION
adds a `duh-export-monitor` command for wrapping blackbox monitors in a way that allows them to be placed on diplomatic edges.

example duh document:
```javascript
{
  component: {
    vendor: 'sifive',
    library: 'blocks',
    name: 'monitor',
    version: '0.1.0',
    busInterfaces: [{
      name: 'ctrl',
      interfaceMode: 'monitor',
      busType: {vendor: 'amba.com', library: 'AMBA4', name: 'AXI4Lite', version: 'r0p0_0'},
      abstractionTypes: [{
        viewRef: 'RTLview',
        portMaps: {
          ACLK:    'clk',
          ARESETn: 'reset',

          AWREADY: 't_ctrl_awready',
          AWVALID: 't_ctrl_awvalid',
          AWADDR:  't_ctrl_awaddr',
          AWPROT:  't_ctrl_awprot',

          WREADY:  't_ctrl_wready',
          WVALID:  't_ctrl_wvalid',
          WDATA:   't_ctrl_wdata',
          WSTRB:   't_ctrl_wstrb',

          BREADY:  't_ctrl_bready',
          BVALID:  't_ctrl_bvalid',
          BRESP:   't_ctrl_bresp',

          ARREADY: 't_ctrl_arready',
          ARVALID: 't_ctrl_arvalid',
          ARADDR:  't_ctrl_araddr',
          ARPROT:  't_ctrl_arprot',

          RREADY:  't_ctrl_rready',
          RVALID:  't_ctrl_rvalid',
          RDATA:   't_ctrl_rdata',
          RRESP:   't_ctrl_rresp'
        },
      }],
    }],
    model: {
      views: [{
        name: 'RTLview',
        displayName: 'RTL View',
        description: 'Simple RTL view of a component.',
        envIdentifier: '*Synthesis:',
        componentInstantiationRef: 'VerilogModel'
      }],
      instantiations: [],
      ports: {
        t_ctrl_awvalid: 1,
        t_ctrl_awready: 1,
        t_ctrl_awaddr: 'addrWidth',
        t_ctrl_awprot: 3,

        t_ctrl_wvalid: 1,
        t_ctrl_wready: 1,
        t_ctrl_wdata: 'dataWidth',
        t_ctrl_wstrb: 'dataWidth / 8',

        t_ctrl_bvalid: 1,
        t_ctrl_bready: 1,
        t_ctrl_bresp: 2,

        t_ctrl_arvalid: 1,
        t_ctrl_arready: 1,
        t_ctrl_araddr: 'addrWidth',
        t_ctrl_arprot: 3,

        t_ctrl_rvalid: 1,
        t_ctrl_rready: 1,
        t_ctrl_rdata: 'dataWidth',
        t_ctrl_rresp: 2,

        reset: 1,
        clk: 1
      }
    },
    pSchema: {
      type: 'object',
      properties: {
        addrWidth: {
          title: 'Address bus width',
          type: 'integer', minimum: 6, maximum: 32, default: 12
        },
        dataWidth: {
          title: 'Data bus width',
          type: 'integer', minimum: 32, maximum: 64, default: 32
        }
      }
    }
  }
}
```

base scala:
```scala
// Generated Code
// Please DO NOT EDIT
package sifive.blocks.monitor

import chisel3._
import chisel3.core.Reset
import freechips.rocketchip.amba.axi4.{AXI4Bundle, AXI4EdgeParameters, AXI4MonitorArgs, AXI4MonitorBase}

case class monitorParams(
  addrWidth: Int = 12,
  dataWidth: Int = 32
)

class monitorBlackBoxIO(
  val addrWidth: Int,
  val dataWidth: Int
) extends Bundle {
  val t_ctrl_awvalid = Input(Bool())
  val t_ctrl_awready = Input(Bool())
  val t_ctrl_awaddr = Input(UInt((addrWidth).W))
  val t_ctrl_awprot = Input(UInt((3).W))
  val t_ctrl_wvalid = Input(Bool())
  val t_ctrl_wready = Input(Bool())
  val t_ctrl_wdata = Input(UInt((dataWidth).W))
  val t_ctrl_wstrb = Input(UInt((dataWidth / 8).W))
  val t_ctrl_bvalid = Input(Bool())
  val t_ctrl_bready = Input(Bool())
  val t_ctrl_bresp = Input(UInt((2).W))
  val t_ctrl_arvalid = Input(Bool())
  val t_ctrl_arready = Input(Bool())
  val t_ctrl_araddr = Input(UInt((addrWidth).W))
  val t_ctrl_arprot = Input(UInt((3).W))
  val t_ctrl_rvalid = Input(Bool())
  val t_ctrl_rready = Input(Bool())
  val t_ctrl_rdata = Input(UInt((dataWidth).W))
  val t_ctrl_rresp = Input(UInt((2).W))
  val reset = Input(Bool())
  val clk = Input(Bool())
}

class monitorBlackBox(
  val addrWidth: Int,
  val dataWidth: Int
) extends BlackBox(Map(
  "addrWidth" -> core.IntParam(addrWidth),
  "dataWidth" -> core.IntParam(dataWidth)
)) {
  val io = IO(new monitorBlackBoxIO(
    addrWidth = addrWidth,
    dataWidth = dataWidth
  ))

  override val desiredName = "monitor"
}

abstract class monitorMonitorBase(params: AXI4MonitorArgs) extends AXI4MonitorBase(params) {
  def getBlackBoxParams(edgeParams: AXI4EdgeParameters): monitorParams

  def connectBlackBoxPorts(
    blackbox: monitorBlackBox,
    bundle: AXI4Bundle,
    edgeParams: AXI4EdgeParameters,
    reset: Reset): Unit = {
    blackbox.io.t_ctrl_awvalid := bundle.aw.valid
    blackbox.io.t_ctrl_awready := bundle.aw.ready
    blackbox.io.t_ctrl_awaddr := bundle.aw.bits.addr
    blackbox.io.t_ctrl_awprot := bundle.aw.bits.prot
    blackbox.io.t_ctrl_wvalid := bundle.w.valid
    blackbox.io.t_ctrl_wready := bundle.w.ready
    blackbox.io.t_ctrl_wdata := bundle.w.bits.data
    blackbox.io.t_ctrl_wstrb := bundle.w.bits.strb
    blackbox.io.t_ctrl_bvalid := bundle.b.valid
    blackbox.io.t_ctrl_bready := bundle.b.ready
    blackbox.io.t_ctrl_bresp := bundle.b.bits.resp
    blackbox.io.t_ctrl_arvalid := bundle.ar.valid
    blackbox.io.t_ctrl_arready := bundle.ar.ready
    blackbox.io.t_ctrl_araddr := bundle.ar.bits.addr
    blackbox.io.t_ctrl_arprot := bundle.ar.bits.prot
    blackbox.io.t_ctrl_rvalid := bundle.r.valid
    blackbox.io.t_ctrl_rready := bundle.r.ready
    blackbox.io.t_ctrl_rdata := bundle.r.bits.data
    blackbox.io.t_ctrl_rresp := bundle.r.bits.resp
  }

  def legalize(
    bundle: AXI4Bundle,
    edgeParams: AXI4EdgeParameters,
    reset: Reset): Unit = {
    val params = getBlackBoxParams(edgeParams)
    val blackbox = Module(new monitorBlackBox(
      addrWidth = params.addrWidth,
      dataWidth = params.dataWidth
    ))
    connectBlackBoxPorts(blackbox, bundle, edgeParams, reset)
  }
}
```

user scala:
```scala
package sifive.blocks.monitor

import chisel3._
import chisel3.core.Reset
import freechips.rocketchip.amba.axi4.{AXI4Bundle, AXI4EdgeParameters, AXI4MonitorArgs, AXI4MonitorBase}

class monitorMonitor(params: AXI4MonitorArgs) extends monitorMonitorBase(params) {
  // IMPLEMENT THIS METHOD: convert the input parameters to blackbox parameters
  def getBlackBoxParams(edgeParams: AXI4EdgeParameters): monitorParams = {
  }

  // if you need to override the default connnection method: uncomment and implement this method
  /*
  override def connectBlackBoxPorts(
    blackbox: monitorBlackBox,
    bundle: AXI4Bundle,
    edgeParams: AXI4EdgeParameters,
    reset: Reset): Unit = {
  }
  */
}
```