### PR TITLE
fix AXI4-Lite typo

### DIFF
--- a/lib/export-scala-base.js
+++ b/lib/export-scala-base.js
@@ -25,7 +25,7 @@ const generators = {
   SPRAM: spram,
   DPRAM: dpram,
   AXI4: axi4Tl,
-  AXI4Lite: axi4Tl,
+  'AXI4-Lite': axi4Tl,
   APB4: apb,
   // AHBLite: ahblite,
   interrupts: intcTl,
@@ -39,7 +39,7 @@ const buses = {
     // },
     AMBA4: {
       AXI4: axi4Tl.busDef,
-      AXI4Lite: axi4Tl.busDef,
+      'AXI4-Lite': axi4Tl.busDef,
       APB4: apb.busDef
     }
   },


### PR DESCRIPTION
duh-bus specifies the name as `AXI4-Lite` instead of `AXI4Lite` so I think we should follow that.