### PR TITLE
make OM mems/ints overrideable, add OMRegisterMaps

### DIFF
--- a/lib/export-scala-base.js
+++ b/lib/export-scala-base.js
@@ -20,6 +20,7 @@ const bundler = require('./export-scala-bundle.js');
 const chisel = require('./chisel-utils.js');
 const paramSchema = require('./param-schema.js');
 
+const genOMRegmap = require('./export-scala-regmap.js').generateOMRegisterMap;
 
 const generators = {
   SPRAM: spram,
@@ -212,6 +213,11 @@ const memorySlaves = comp => comp
 module.exports = p => {
   const comp = p.component || {};
   const pSchema = comp.pSchema || {};
+  const omRegisterMaps = (p.component.memoryMaps || []).flatMap(memoryMap => {
+    return (memoryMap.addressBlocks || []).map(addressBlock => {
+      return genOMRegmap(addressBlock);
+    });
+  });
   return `// Generated Code
 // Please DO NOT EDIT
 
@@ -341,35 +347,28 @@ ${
 
 class N${comp.name}TopLogicalTreeNode(component: N${comp.name}TopBase) extends LogicalTreeNode(() => Some(component.imp.device)) {
   override def getOMComponents(resourceBindings: ResourceBindings, components: Seq[OMComponent]): Seq[OMComponent] = {
-    DiplomaticObjectModelAddressing.getOMComponentHelper(
-      resourceBindings, (resources) => {
-        val name = component.imp.device.describe(resourceBindings).name
-        val omDevice = new scala.collection.mutable.LinkedHashMap[String, Any] with OMDevice {
-          val memoryRegions: Seq[OMMemoryRegion] =
-            DiplomaticObjectModelAddressing.getOMMemoryRegions(name, resourceBindings, None)
+    val name = component.imp.device.describe(resourceBindings).name
+    val omDevice = new scala.collection.mutable.LinkedHashMap[String, Any] with OMDevice {
+      val memoryRegions = component.getOMMemoryRegions(resourceBindings)
+      val interrupts = component.getOMInterrupts(resourceBindings)
+      val _types: Seq[String] = Seq("OM${comp.name}", "OMDevice", "OMComponent", "OMCompoundType")
+    }
+    val userOM = component.userOM
+    val values = userOM.productIterator
+    if (values.nonEmpty) {
+      val pairs = (userOM.getClass.getDeclaredFields.map { field =>
+        assert(field.getName != "memoryRegions", "user Object Model must not define \\"memoryRegions\\"")
+        assert(field.getName != "interrupts", "user Object Model must not define \\"interrupts\\"")
+        assert(field.getName != "_types", "user Object Model must not define \\"_types\\"")
 
-          val interrupts: Seq[OMInterrupt] =
-            DiplomaticObjectModelAddressing.describeGlobalInterrupts(name, resourceBindings)
-
-          val _types: Seq[String] = Seq("OM${comp.name}", "OMDevice", "OMComponent", "OMCompoundType")
-        }
-        val userOM = component.userOM
-        val values = userOM.productIterator
-        if (values.nonEmpty) {
-          val pairs = (userOM.getClass.getDeclaredFields.map { field =>
-            assert(field.getName != "memoryRegions", "user Object Model must not define \\"memoryRegions\\"")
-            assert(field.getName != "interrupts", "user Object Model must not define \\"interrupts\\"")
-            assert(field.getName != "_types", "user Object Model must not define \\"_types\\"")
-
-            field.getName -> values.next
-          }).toSeq
-          omDevice ++= pairs
-        }
-        omDevice("memoryRegions") = omDevice.memoryRegions
-        omDevice("interrupts") = omDevice.interrupts
-        omDevice("_types") = omDevice._types
-        Seq(omDevice)
-      })
+        field.getName -> values.next
+      }).toSeq
+      omDevice ++= pairs
+    }
+    omDevice("memoryRegions") = omDevice.memoryRegions
+    omDevice("interrupts") = omDevice.interrupts
+    omDevice("_types") = omDevice._types
+    Seq(omDevice)
   }
 }
 
@@ -382,6 +381,19 @@ class N${comp.name}TopBase(val c: N${comp.name}TopParams)(implicit p: Parameters
   ResourceBinding { Resource(imp.device, "exists").bind(ResourceString("yes")) }
 
   def userOM: Product with Serializable = Nil
+
+  def omRegisterMaps = Seq(
+${indent(4)(omRegisterMaps.join(',\n'))})
+
+  def getOMMemoryRegions(resourceBindings: ResourceBindings): Seq[OMMemoryRegion] = {
+    val name = imp.device.describe(resourceBindings).name
+    DiplomaticObjectModelAddressing.getOMMemoryRegions(name, resourceBindings, None)
+  }
+
+  def getOMInterrupts(resourceBindings: ResourceBindings): Seq[OMInterrupt] = {
+    val name = imp.device.describe(resourceBindings).name
+    DiplomaticObjectModelAddressing.describeGlobalInterrupts(name, resourceBindings)
+  }
 
   def logicalTreeNode: LogicalTreeNode = new N${comp.name}TopLogicalTreeNode(this)
 

--- a/lib/export-scala-base.js
+++ b/lib/export-scala-base.js
@@ -213,11 +213,11 @@ const memorySlaves = comp => comp
 module.exports = p => {
   const comp = p.component || {};
   const pSchema = comp.pSchema || {};
-  const omRegisterMaps = (p.component.memoryMaps || []).flatMap(memoryMap => {
-    return (memoryMap.addressBlocks || []).map(addressBlock => {
+  const omRegisterMaps = (p.component.memoryMaps || []).reduce((acc, memoryMap) => {
+    return acc.concat((memoryMap.addressBlocks || []).map(addressBlock => {
       return genOMRegmap(addressBlock);
-    });
-  });
+    }));
+  }, []);
   return `// Generated Code
 // Please DO NOT EDIT
 

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -292,4 +292,24 @@ const exportRegmap = comp => {
   };
 };
 
-module.exports = exportRegmap;
+const generateOMRegisterMap = (addressBlock) => {
+  const registerMapElements = addressBlock.registers.map((register) => {
+    const regFieldSeqElements = (register.fields || []).map(field => {
+      const access = field.access || register.access || addressBlock.access;
+      return generateRegisterField(field, 'Bool()', access);
+    });
+
+    const registerDesc = register.description ? `Some("${register.description}")` : 'None';
+
+    return `${register.addressOffset} -> RegFieldGroup("${register.name}", ${registerDesc}, Seq(
+${indent(2, ',')(regFieldSeqElements)}))`;
+  });
+
+  return `OMRegister.convert(
+${indent(2)(registerMapElements.join(',\n'))})`;
+};
+
+module.exports = {
+  exportRegmap: exportRegmap,
+  generateOMRegisterMap: generateOMRegisterMap
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,5 +9,5 @@ const exportScalaMonitor = require('./export-scala-monitor.js');
 exports.fileWriter = fileWriter;
 exports.exportScalaBase = exportScalaBase;
 exports.exportScalaUser = exportScalaUser;
-exports.exportScalaRegMap = exportScalaRegMap;
+exports.exportScalaRegMap = exportScalaRegMap.exportRegmap;
 exports.exportScalaMonitor = exportScalaMonitor;


### PR DESCRIPTION
this adds a methods `getOMMemoryRegions`, `getOMInterrupts`, and `omRegisterMaps` to the `N*TopBase` class. This allows users to override the `OMMemoryRegion`s and `OMInterrupt`s that get included in the `OMDevice`. `omRegisterMaps` provides default `OMRegisterMap`s for the registers described in the DUH document.

With these methods the user can associate memory regions with register maps in their user code and generate `OMMemoryRegsion`s with register descriptions in their object model.