### PR TITLE
use endent for code blocks, cleanup

### DIFF
--- a/lib/chisel-utils.js
+++ b/lib/chisel-utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const indent = require('./indent.js');
+const endent = require('endent');
+const traverseSpec = require('./traverse-spec.js');
 
 const convertType = (width) => {
   return (width === 1 ? 'Bool()' : 'UInt((' + width + ').W)');
@@ -30,9 +31,11 @@ const generateCaseClass = ({className, fields}) => {
       return `${field.name}: ${field.type}`;
     }
   });
-  return `case class ${className}(
-${indent(2, ',')(params)}
-)`;
+  return endent`
+    case class ${className}(
+      ${params.join(',\n')}
+    )
+  `;
 };
 
 const generateBundle = ({ports, className, paramsMap}) => {
@@ -49,11 +52,13 @@ const generateBundle = ({ports, className, paramsMap}) => {
     return `val ${key}: ${value}`;
   });
 
-  const stringValue = `class ${className}(
-${indent(2, ',')(stringParams)}
-) extends Bundle {
-${indent(2)(body)}
-}`;
+  const stringValue = endent`
+    class ${className}(
+      ${stringParams.join(',\n')}
+    ) extends Bundle {
+      ${body.join('\n')}
+    }
+  `;
 
   return stringValue;
 };
@@ -75,6 +80,24 @@ const convertParam = ({type, value}) => {
   }
 };
 
+const serializeImports = (imports, startPathOpt) => {
+  var result = [];
+  const startPath = startPathOpt || [];
+  traverseSpec({
+    leaf: (node, path) => {
+      const packagePath = startPath.concat(path);
+      if (Array.isArray(node)) {
+        node.forEach(last => {
+          result.push(serializeImports(last, packagePath));
+        });
+      } else {
+        result.push('import ' + packagePath.concat(node).join('.'));
+      }
+    }
+  })(imports);
+  return result.join('\n');
+};
+
 const generateBlackBox = ({className, paramsMap, blackboxParamsMap, ioType, ioParamsMap, desiredName}) => {
 
   const stringParams = Object.entries(paramsMap).map(([key, value]) => {
@@ -88,17 +111,20 @@ const generateBlackBox = ({className, paramsMap, blackboxParamsMap, ioType, ioPa
   const stringIOParams = Object.entries(ioParamsMap).map(([key, value]) => {
     return `${key} = ${value}`;
   });
-  const stringValue = `class ${className}(
-${indent(2, ',')(stringParams)}
-) extends BlackBox(Map(
-${indent(2, ',')(stringBlackBoxParams)}
-)) {
-  val io = IO(new ${ioType}(
-${indent(4, ',')(stringIOParams)}
-  ))
 
-  override val desiredName = "${desiredName}"
-}`;
+  const stringValue = endent`
+    class ${className}(
+      ${stringParams.join(',\n')}
+    ) extends BlackBox(Map(
+      ${stringBlackBoxParams.join(',\n')}
+    )) {
+      val io = IO(new ${ioType}(
+        ${stringIOParams.join(',\n')}
+      ))
+
+      override val desiredName = "${desiredName}"
+    }
+  `;
 
   return stringValue;
 };
@@ -109,5 +135,6 @@ module.exports = {
   convertType: convertType,
   convertDirection: convertDirection,
   convertParam: convertParam,
-  generateCaseClass: generateCaseClass
+  generateCaseClass: generateCaseClass,
+  serializeImports: serializeImports
 };

--- a/lib/export-scala-monitor.js
+++ b/lib/export-scala-monitor.js
@@ -5,6 +5,7 @@ const traverseSpec = require('../lib/traverse-spec');
 const flipString = require('../lib/flip-string');
 
 const indent = require('./indent');
+const endent = require('endent');
 const get = require('lodash.get');
 const axi4 = require('./axi4-tl');
 const apb = require('./apb-scala');
@@ -107,56 +108,60 @@ const generateMonitor = (component, names, generator) => {
   });
 
   const blackboxComponents = generateBlackBoxComponents(component, names);
+  const monitorBaseClass = endent`
+    abstract class ${monitorNames.baseName}(${monitorNames.args}: ${generatorNames.args}) extends ${generatorNames.baseMonitor}(${monitorNames.args}) {
+      def ${paramsNames.name}(${paramsNames.edgeParams}: ${generatorNames.edgeParams}): ${component.name}Params
+
+      def ${connectNames.name}(
+        ${connectNames.blackbox}: ${names.blackbox.name},
+        ${connectNames.bundle}: ${generatorNames.bundle},
+        ${connectNames.edgeParams}: ${generatorNames.edgeParams},
+        ${connectNames.reset}: Reset): Unit = {
+    ${indent(4)(connects)}
+      }
+
+      def ${legalizeNames.name}(
+        ${legalizeNames.bundle}: ${generatorNames.bundle},
+        ${legalizeNames.edgeParams}: ${generatorNames.edgeParams},
+        ${legalizeNames.reset}: Reset): Unit = {
+        val params = ${paramsNames.name}(${legalizeNames.edgeParams})
+        val blackbox = Module(new ${names.blackbox.name}(
+    ${indent(6, ',')(blackboxArgsAssign)}
+        ))
+        ${names.monitor.connectMethod.name}(blackbox, ${legalizeNames.bundle}, ${legalizeNames.edgeParams}, ${legalizeNames.reset})
+      }
+    }
+  `;
 
   return {
     base: {
-      imports: ['chisel3._', 'chisel3.core.Reset'].concat(generator.monitor.imports),
-      body: `${blackboxComponents.params}
-
-${blackboxComponents.bundle}
-
-${blackboxComponents.module}
-
-abstract class ${monitorNames.baseName}(${monitorNames.args}: ${generatorNames.args}) extends ${generatorNames.baseMonitor}(${monitorNames.args}) {
-  def ${paramsNames.name}(${paramsNames.edgeParams}: ${generatorNames.edgeParams}): ${component.name}Params
-
-  def ${connectNames.name}(
-    ${connectNames.blackbox}: ${names.blackbox.name},
-    ${connectNames.bundle}: ${generatorNames.bundle},
-    ${connectNames.edgeParams}: ${generatorNames.edgeParams},
-    ${connectNames.reset}: Reset): Unit = {
-${indent(4)(connects)}
-  }
-
-  def ${legalizeNames.name}(
-    ${legalizeNames.bundle}: ${generatorNames.bundle},
-    ${legalizeNames.edgeParams}: ${generatorNames.edgeParams},
-    ${legalizeNames.reset}: Reset): Unit = {
-    val params = ${paramsNames.name}(${legalizeNames.edgeParams})
-    val blackbox = Module(new ${names.blackbox.name}(
-${indent(6, ',')(blackboxArgsAssign)}
-    ))
-    ${names.monitor.connectMethod.name}(blackbox, ${legalizeNames.bundle}, ${legalizeNames.edgeParams}, ${legalizeNames.reset})
-  }
-}`
+      imports: ['chisel3._', 'chisel3.core.Reset', generator.monitor.imports],
+      blocks: [
+        blackboxComponents.params,
+        blackboxComponents.bundle,
+        blackboxComponents.module,
+        monitorBaseClass
+      ]
     },
     user: {
       imports: ['chisel3._', 'chisel3.core.Reset'].concat(generator.monitor.imports),
-      body: `class ${monitorNames.userName}(${names.monitor.args}: ${generatorNames.args}) extends ${names.monitor.baseName}(${names.monitor.args}) {
-  // IMPLEMENT THIS METHOD: convert the input parameters to blackbox parameters
-  def ${paramsNames.name}(${paramsNames.edgeParams}: ${generatorNames.edgeParams}): ${component.name}Params = {
-  }
+      blocks: [endent`
+        class ${monitorNames.userName}(${names.monitor.args}: ${generatorNames.args}) extends ${names.monitor.baseName}(${names.monitor.args}) {
+          // IMPLEMENT THIS METHOD: convert the input parameters to blackbox parameters
+          def ${paramsNames.name}(${paramsNames.edgeParams}: ${generatorNames.edgeParams}): ${component.name}Params = {
+          }
 
-  // if you need to override the default connnection method: uncomment and implement this method
-  /*
-  override def ${connectNames.name}(
-    ${connectNames.blackbox}: ${names.blackbox.name},
-    ${connectNames.bundle}: ${generatorNames.bundle},
-    ${connectNames.edgeParams}: ${generatorNames.edgeParams},
-    ${connectNames.reset}: Reset): Unit = {
-  }
-  */
-}`
+          // if you need to override the default connnection method: uncomment and implement this method
+          /*
+          override def ${connectNames.name}(
+            ${connectNames.blackbox}: ${names.blackbox.name},
+            ${connectNames.bundle}: ${generatorNames.bundle},
+            ${connectNames.edgeParams}: ${generatorNames.edgeParams},
+            ${connectNames.reset}: Reset): Unit = {
+          }
+          */
+        }
+      `]
     }
   };
 };
@@ -218,28 +223,24 @@ const exportMonitor = comp => {
   const generator = getGenerator(comp);
   const monitor = generateMonitor(comp, names, generator);
 
-  const extraBaseImports = monitor.base.imports.map(i => {
-    return `import ${i}`;
-  });
-  const extraUserImports = monitor.user.imports.map(i => {
-    return `import ${i}`;
-  });
+  const base = endent`
+    // Generated Code
+    // Please DO NOT EDIT
+    package ${comp.vendor}.${comp.library}.${comp.name}
 
-  const base = `// Generated Code
-// Please DO NOT EDIT
-package ${comp.vendor}.${comp.library}.${comp.name}
+    ${chisel.serializeImports(monitor.base.imports)}
 
-${extraBaseImports.join('\n')}
+    ${monitor.base.blocks.join('\n\n')}
+  `;
 
-${monitor.base.body}
-`;
+  const user = endent`
+    package ${comp.vendor}.${comp.library}.${comp.name}
 
-  const user = `package ${comp.vendor}.${comp.library}.${comp.name}
+    ${chisel.serializeImports(monitor.user.imports)}
 
-${extraUserImports.join('\n')}
+    ${monitor.user.blocks.join('\n\n')}
+  `;
 
-${monitor.user.body}
-`;
   const result = {
     base: {},
     user: {}

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const chisel = require('./chisel-utils.js');
+const endent = require('endent');
 const indent = require('./indent.js');
 
 //// GNERATE BUNDLES ////
@@ -55,11 +57,10 @@ const generateAddressBlockBundles = addressBlock => {
 
   const names = getAddressBlockNames(addressBlock);
 
-  return `${registerBundles.join('\n\n')}
-
-class ${names.ioBundle} extends Bundle {
-${indent(2)(bundleFields.join('\n'))}
-}`;
+  return registerBundles.concat(endent`
+    class ${names.ioBundle} extends Bundle {
+      ${bundleFields.join('\n')}
+    }`);
 };
 
 
@@ -98,8 +99,9 @@ const generateRegister = (access, register, addressBlockNames) => {
 
   const registerDesc = register.description ? `Some("${register.description}")` : 'None';
 
-  return `${register.addressOffset} -> RegFieldGroup("${register.name}", ${registerDesc}, Seq(
-${indent(2)(regFieldSeqElements.join(',\n'))}))`;
+  return endent`
+    ${register.addressOffset} -> RegFieldGroup("${register.name}", ${registerDesc}, Seq(
+      ${regFieldSeqElements.join(',\n')}))`;
 };
 
 const generateRegisterResetParams = (register, addressBlockNames) => {
@@ -108,14 +110,16 @@ const generateRegisterResetParams = (register, addressBlockNames) => {
 
   const registerResetValues = getRegisterFields(register).map((field, idx) => {
     const paramName = getScalaBundleRegFieldName(field, idx);
-    return `def ${paramName}: UInt =
-  ${baseParamsName}.${paramName}`;
+    return endent`
+      def ${paramName}: UInt =
+        ${baseParamsName}.${paramName}`;
   });
 
   const objectName = register.name;
-  return `object ${objectName} {
-${indent(2)(registerResetValues.join('\n'))}
-}`;
+  return endent`
+    object ${objectName} {
+      ${registerResetValues.join('\n')}
+    }`;
 };
 
 const generateRegisterResetBaseParams = (register) => {
@@ -126,9 +130,10 @@ const generateRegisterResetBaseParams = (register) => {
   });
 
   const objectName = register.name;
-  return `object ${objectName} {
-${indent(2)(registerResetValues.join('\n'))}
-}`;
+  return endent`
+    object ${objectName} {
+      ${registerResetValues.join('\n')}
+    }`;
 };
 
 const generateRegisterReset = (access, register, addressBlockNames) => {
@@ -170,7 +175,7 @@ const getAddressBlockNames = addressBlock => {
   };
 };
 
-const generateBodyBase = (names, addressBlock, packageName, deviceNameString, compatString) => {
+const generateBodyBase = (names, addressBlock, deviceNameString, compatString) => {
   const registerMapElements = addressBlock.registers.map((register) => {
     return generateRegister(register.access || addressBlock.access, register, names);
   });
@@ -184,81 +189,88 @@ const generateBodyBase = (names, addressBlock, packageName, deviceNameString, co
   });
 
   const bundleDefs = generateAddressBlockBundles(addressBlock);
+  const baseParamsObject = endent`
+    object ${names.baseParamsObject.name} {
+      def ${names.baseParamsObject.deviceTreeName}: String = ${deviceNameString}
+      def ${names.baseParamsObject.deviceTreeCompat}: Seq[String] = Seq(${compatString})
 
-  return `// Generated Code
-// Please DO NOT EDIT
+      object ${names.baseParamsObject.resetValues} {
+    ${indent(4)(resetParamElements.join('\n\n'))}
+      }
+    }
+  `;
+  const registerRouter = endent`
+    abstract class ${names.regRouter}(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
+      extends IORegisterRouter(
+        RegisterRouterParams(
+          name = ${names.userParamsObject.name}.${names.userParamsObject.deviceTreeName},
+          compat = ${names.userParamsObject.name}.${names.userParamsObject.deviceTreeCompat},
+          base = baseAddress,
+          beatBytes = busWidthBytes),
+        new ${names.ioBundle}) {
 
+      lazy val module = new LazyModuleImp(this) {
+        val portValue = ioNode.makeIO()
+        val ${names.regMapResetWire} = Wire(portValue.cloneType.asOutput)
+    ${indent(4)(resetElements.join('\n'))}
 
-${packageName}
+        val ${names.regMapRegister} = RegInit(resetValue)
+        portValue <> ${names.regMapRegister}
 
-import chisel3._
+        val mapping = Seq(
+    ${indent(6)(registerMapElements.join(',\n'))})
+        regmap(mapping:_*)
+      }
+    }
+  `;
 
-import freechips.rocketchip.config.Parameters
-import freechips.rocketchip.diplomacy.LazyModuleImp
-import freechips.rocketchip.regmapper._
-import freechips.rocketchip.tilelink.HasTLControlRegMap
-import freechips.rocketchip.amba.axi4.HasAXI4ControlRegMap
+  const tlRegisterRouter = endent`
+    class ${names.tlRegMap}(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
+      extends ${names.regRouter}(busWidthBytes, baseAddress) with HasTLControlRegMap
+  `;
 
-${bundleDefs}
+  const axi4RegisterRouter = endent`
+    class ${names.axi4RegMap}AXI4RegMap(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
+      extends ${names.regRouter}(busWidthBytes, baseAddress) with HasAXI4ControlRegMap
+  `;
 
-object ${names.baseParamsObject.name} {
-  def ${names.baseParamsObject.deviceTreeName}: String = ${deviceNameString}
-  def ${names.baseParamsObject.deviceTreeCompat}: Seq[String] = Seq(${compatString})
-
-  object ${names.baseParamsObject.resetValues} {
-${indent(4)(resetParamElements.join('\n\n'))}
-  }
-}
-
-abstract class ${names.regRouter}(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
-  extends IORegisterRouter(
-    RegisterRouterParams(
-      name = ${names.userParamsObject.name}.${names.userParamsObject.deviceTreeName},
-      compat = ${names.userParamsObject.name}.${names.userParamsObject.deviceTreeCompat},
-      base = baseAddress,
-      beatBytes = busWidthBytes),
-    new ${names.ioBundle}) {
-
-  lazy val module = new LazyModuleImp(this) {
-    val portValue = ioNode.makeIO()
-    val ${names.regMapResetWire} = Wire(portValue.cloneType.asOutput)
-${indent(4)(resetElements.join('\n'))}
-
-    val ${names.regMapRegister} = RegInit(resetValue)
-    portValue <> ${names.regMapRegister}
-
-    val mapping = Seq(
-${indent(6)(registerMapElements.join(',\n'))})
-    regmap(mapping:_*)
-  }
-}
-
-class ${names.tlRegMap}(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
-  extends ${names.regRouter}(busWidthBytes, baseAddress) with HasTLControlRegMap
-
-class ${names.axi4RegMap}AXI4RegMap(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
-  extends ${names.regRouter}(busWidthBytes, baseAddress) with HasAXI4ControlRegMap
-`;
+  return {
+    imports: {
+      chisel3: '_',
+      'freechips.rocketchip': [
+        'amba.axi4.HasAXI4ControlRegMap',
+        'config.Parameters',
+        'diplomacy.LazyModuleImp',
+        'regmapper._',
+        'tilelink.HasTLControlRegMap'
+      ]
+    },
+    blocks: bundleDefs.concat([
+      baseParamsObject,
+      registerRouter,
+      tlRegisterRouter,
+      axi4RegisterRouter
+    ])
+  };
 };
 
-const generateBodyUser = (names, addressBlock, packageName) => {
+const generateBodyUser = (names, addressBlock) => {
   const resetParamElements = addressBlock.registers.map((register) => {
     return generateRegisterResetParams(register, names);
   });
+  return {
+    imports: ['chisel3._'],
+    blocks: [endent`
+      object ${names.userParamsObject.name} {
+        def ${names.userParamsObject.deviceTreeName}: String = ${names.baseParamsObject.name}.${names.baseParamsObject.deviceTreeName}
+        def ${names.userParamsObject.deviceTreeCompat}: Seq[String] = ${names.baseParamsObject.name}.${names.baseParamsObject.deviceTreeCompat}
 
-  return `${packageName}
-
-import chisel3._
-
-object ${names.userParamsObject.name} {
-  def ${names.userParamsObject.deviceTreeName}: String = ${names.baseParamsObject.name}.${names.baseParamsObject.deviceTreeName}
-  def ${names.userParamsObject.deviceTreeCompat}: Seq[String] = ${names.baseParamsObject.name}.${names.baseParamsObject.deviceTreeCompat}
-
-  object ${names.userParamsObject.resetValues} {
-${indent(4)(resetParamElements.join('\n\n'))}
-  }
-}
-`;
+        object ${names.userParamsObject.resetValues} {
+          ${resetParamElements.join('\n\n')}
+        }
+      }
+    `]
+  };
 };
 
 const exportRegmap = comp => {
@@ -278,8 +290,26 @@ const exportRegmap = comp => {
       const deviceNameString = `"${comp.name}-${addressBlock.name}"`;
       const names = getAddressBlockNames(addressBlock);
 
-      memoryMapBaseResult[`${addressBlock.name}-base`] = generateBodyBase(names, addressBlock, packageName, deviceNameString, compatString);
-      memoryMapUserResult[addressBlock.name] = generateBodyUser(names, addressBlock, packageName);
+      const base = generateBodyBase(names, addressBlock, deviceNameString, compatString);
+      const user = generateBodyUser(names, addressBlock);
+
+      memoryMapBaseResult[`${addressBlock.name}-base`] = endent`
+        // Generated Code
+        // Please DO NOT EDIT
+        package ${packageName}
+
+        ${chisel.serializeImports(base.imports)}
+
+        ${base.blocks.join('\n\n')}
+      `;
+
+      memoryMapUserResult[addressBlock.name] = endent`
+        package ${packageName}
+
+        ${chisel.serializeImports(user.imports)}
+
+        ${user.blocks.join('\n\n')}
+      `;
     });
 
     baseResult[memoryMap.name] = memoryMapBaseResult;
@@ -305,8 +335,9 @@ const generateOMRegisterMap = (addressBlock) => {
 ${indent(2, ',')(regFieldSeqElements)}))`;
   });
 
-  return `OMRegister.convert(
-${indent(2)(registerMapElements.join(',\n'))})`;
+  return endent`
+    OMRegister.convert(
+      ${registerMapElements.join(',\n')})`;
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "duh-core": "^0.5.0",
+    "endent": "^1.3.0",
     "fs-extra": "^8.1.0",
     "lodash.get": "^4.4.2",
     "scalameta-parsers": "^4.2.1",


### PR DESCRIPTION
use endent package to strip leading whitespace from template strings. also do some refactors to breakup some of the really big template strings and make things a little more organized.