### PR TITLE
update export-scala-regmap for duh-schema 0.7.1

### DIFF
--- a/lib/chisel-utils.js
+++ b/lib/chisel-utils.js
@@ -81,6 +81,10 @@ const convertParam = ({type, value}) => {
 };
 
 const serializeImports = (imports, startPathOpt) => {
+  if (!imports) {
+    return '';
+  }
+
   var result = [];
   const startPath = startPathOpt || [];
   traverseSpec({
@@ -98,7 +102,13 @@ const serializeImports = (imports, startPathOpt) => {
   return result.join('\n');
 };
 
-const generateBlackBox = ({className, paramsMap, blackboxParamsMap, ioType, ioParamsMap, desiredName}) => {
+const generateBlackBox = ({
+  className,
+  paramsMap,
+  blackboxParamsMap,
+  ioType,
+  ioParamsMap,
+  desiredName}) => {
 
   const stringParams = Object.entries(paramsMap).map(([key, value]) => {
     return `val ${key}: ${value}`;
@@ -125,7 +135,6 @@ const generateBlackBox = ({className, paramsMap, blackboxParamsMap, ioType, ioPa
       override val desiredName = "${desiredName}"
     }
   `;
-
   return stringValue;
 };
 

--- a/lib/export-scala-base.js
+++ b/lib/export-scala-base.js
@@ -20,7 +20,7 @@ const bundler = require('./export-scala-bundle.js');
 const chisel = require('./chisel-utils.js');
 const paramSchema = require('./param-schema.js');
 
-const genOMRegmap = require('./export-scala-regmap.js').generateOMRegisterMap;
+const regmap = require('./export-scala-regmap.js');
 
 const generators = {
   SPRAM: spram,
@@ -215,7 +215,7 @@ module.exports = p => {
   const pSchema = comp.pSchema || {};
   const omRegisterMaps = (p.component.memoryMaps || []).reduce((acc, memoryMap) => {
     return acc.concat((memoryMap.addressBlocks || []).map(addressBlock => {
-      return genOMRegmap(addressBlock);
+      return regmap.generateOMRegisterMap(addressBlock);
     }));
   }, []);
   return `// Generated Code
@@ -381,6 +381,8 @@ class N${comp.name}TopBase(val c: N${comp.name}TopParams)(implicit p: Parameters
   ResourceBinding { Resource(imp.device, "exists").bind(ResourceString("yes")) }
 
   def userOM: Product with Serializable = Nil
+
+${indent(2)(regmap.padFieldsMethod)}
 
   def omRegisterMaps = Seq(
 ${indent(4)(omRegisterMaps.join(',\n'))})

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -3,7 +3,6 @@
 const chisel = require('./chisel-utils.js');
 const endent = require('endent');
 const paramSchema = require('./param-schema.js');
-const indent = require('./indent.js');
 
 //// GNERATE BUNDLES ////
 
@@ -198,6 +197,28 @@ const getAddressBlockNames = addressBlock => {
   };
 };
 
+const padFieldsMethod = endent`
+  private def padFields(fields: (Int, RegField)*) = {
+    var previousOffset = 0
+    var previousField: Option[RegField] = None
+
+    fields.flatMap { case (fieldOffset, field) =>
+      val padWidth = fieldOffset - previousOffset
+      require(padWidth >= 0,
+        previousField.map(f => s"register fields at $previousOffset and $fieldOffset are overlapping")
+          .getOrElse(s"register field $field has a negative offset"))
+
+      previousOffset = fieldOffset
+      previousField = Some(field)
+
+      if (padWidth > 0) {
+        Seq(RegField(padWidth), field)
+      } else {
+        Seq(field)
+      }
+    }
+  }`;
+
 const generateBodyBase = ({
   names,
   addressBlock,
@@ -224,7 +245,7 @@ const generateBodyBase = ({
       def ${names.baseParamsObject.deviceTreeCompat}: Seq[String] = Seq(${compatString})
 
       object ${names.baseParamsObject.resetValues} {
-    ${indent(4)(resetParamElements.join('\n\n'))}
+        ${resetParamElements.join('\n\n')}
       }
     }
   `;
@@ -246,26 +267,7 @@ const generateBodyBase = ({
           beatBytes = busWidthBytes),
         new ${names.ioBundle}(${names.paramsName})) {
 
-      private def padFields(fields: (Int, RegField)*) = {
-        var previousOffset = 0
-        var previousField: Option[RegField] = None
-
-        fields.flatMap { case (fieldOffset, field) =>
-          val padWidth = fieldOffset - previousOffset
-          require(padWidth >= 0,
-            previousField.map(f => s"register fields at $previousOffset and $fieldOffset are overlapping")
-              .getOrElse(s"register field $field has a negative offset"))
-
-          previousOffset = fieldOffset
-          previousField = Some(field)
-
-          if (padWidth > 0) {
-            Seq(RegField(padWidth), field)
-          } else {
-            Seq(field)
-          }
-        }
-      }
+      ${padFieldsMethod}
 
       lazy val module = new LazyModuleImp(this) {
         val portValue = ioNode.makeIO()
@@ -436,13 +438,14 @@ const generateOMRegisterMap = (addressBlock) => {
   const registerMapElements = addressBlock.registers.map((register) => {
     const regFieldSeqElements = (register.fields || []).map(field => {
       const access = field.access || register.access || addressBlock.access;
-      return generateRegisterField(field, 'Bool()', access);
+      return `${field.bitOffset} -> ` + generateRegisterField(field, 'Bool()', access);
     });
 
     const registerDesc = register.description ? `Some("${register.description}")` : 'None';
 
-    return `${register.addressOffset} -> RegFieldGroup("${register.name}", ${registerDesc}, Seq(
-${indent(2, ',')(regFieldSeqElements)}))`;
+    return endent`
+      ${register.addressOffset} -> RegFieldGroup("${register.name}", ${registerDesc}, padFields(
+        ${regFieldSeqElements}))`;
   });
 
   return endent`
@@ -452,5 +455,6 @@ ${indent(2, ',')(regFieldSeqElements)}))`;
 
 module.exports = {
   exportRegmap: exportRegmap,
-  generateOMRegisterMap: generateOMRegisterMap
+  generateOMRegisterMap: generateOMRegisterMap,
+  padFieldsMethod: padFieldsMethod
 };

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -2,6 +2,7 @@
 
 const chisel = require('./chisel-utils.js');
 const endent = require('endent');
+const paramSchema = require('./param-schema.js');
 const indent = require('./indent.js');
 
 //// GNERATE BUNDLES ////
@@ -15,10 +16,10 @@ const getScalaRegisterBundleName = (register) => {
 };
 
 const getRegisterFields = register => {
-  return register.fields || [{bits: register.size}];
+  return register.fields || [{bitOffset: 0, bitWidth: register.size}];
 };
 
-const generateRegisterBundle = (access, register) => {
+const generateRegisterBundle = (access, register, blackboxParams) => {
   const fields = getRegisterFields(register).map((field, idx) => {
     const fieldAccess = field.access || access;
     if (fieldAccess) {
@@ -35,30 +36,45 @@ const generateRegisterBundle = (access, register) => {
           throw new Error(`invalid access field value: ${access}`);
         }
       })(fieldAccess);
-      return `val ${getScalaBundleRegFieldName(field, idx)} = ${direction}(UInt(${field.bits}.W))`;
+      return `val ${getScalaBundleRegFieldName(field, idx)} = ${direction}(UInt(${field.bitWidth}.W))`;
     } else {
-      return `// PAD ${field.bits}`;
+      return `// PAD ${field.bitWidth}`;
     }
   });
 
-  return `class ${getScalaRegisterBundleName(register)} extends Bundle {
-${indent(2)(fields.join('\n'))}
-}`;
+  //TODO: only Int params supported
+  const params = blackboxParams.fields.map(param => {
+    return `val ${param.name}: Int`;
+  });
+
+  return endent`
+  class ${getScalaRegisterBundleName(register)}(
+    ${params.join(',\n')}
+  ) extends Bundle {
+    ${fields.join('\n')}
+  }`;
 };
 
-const generateAddressBlockBundles = addressBlock => {
+const generateAddressBlockBundles = (addressBlock, blackboxParams) => {
   const registerBundles = addressBlock.registers.map((register) => {
-    return generateRegisterBundle(register.access || addressBlock.access, register);
+    return generateRegisterBundle(register.access || addressBlock.access, register, blackboxParams);
   });
 
   const bundleFields = addressBlock.registers.map((register) => {
-    return `val ${register.name} = new ${getScalaRegisterBundleName(register)}()`;
+    const params = blackboxParams.fields.map(field => {
+      return `${field.name} = params.${field.name}`;
+    });
+
+    return endent`
+      val ${register.name} = new ${getScalaRegisterBundleName(register)}(
+        ${params.join(',\n')}
+      )`;
   });
 
   const names = getAddressBlockNames(addressBlock);
 
   return registerBundles.concat(endent`
-    class ${names.ioBundle} extends Bundle {
+    class ${names.ioBundle}(val params: ${blackboxParams.className}) extends Bundle {
       ${bundleFields.join('\n')}
     }`);
 };
@@ -68,24 +84,30 @@ const generateAddressBlockBundles = addressBlock => {
 
 const generateRegisterField = (field, scalaRegisterName, access) => {
   if (access) {
-    const regFieldDesc = field.name || field.desc ?
-      `RegFieldDesc(${field.name ? `"${field.name}"` : '""'}, ${field.desc ? `"${field.desc}"` : '""'})` :
-      '';
-
+    var result = '';
     switch (access) {
     case 'read-write':
     case 'read-writeOnce':
-      return `RegField(${field.bits}, ${scalaRegisterName}, ${regFieldDesc})`;
+      result += 'RegField';
+      break;
     case 'read-only':
-      return `RegField.r(${field.bits}, ${scalaRegisterName}, ${regFieldDesc})`;
+      result += 'RegField.r';
+      break;
     case 'write-only':
     case 'writeOnce':
-      return `RegField.w(${field.bits}, ${scalaRegisterName}, ${regFieldDesc})`;
+      result += 'RegField.w';
+      break;
     default:
       throw new Error(`invalid access field value: ${access}`);
     }
+    result += `(${field.bitWidth}, ${scalaRegisterName}`;
+    if (field.name || field.desc) {
+      result += `, RegFieldDesc("${field.name || ''}", "${field.desc || ''}")`;
+    }
+    result += ')';
+    return result;
   } else {
-    return `RegField(${field.bits})`;
+    return `RegField(${field.bitWidth})`;
   }
 };
 
@@ -94,13 +116,13 @@ const generateRegister = (access, register, addressBlockNames) => {
 
   const regFieldSeqElements = getRegisterFields(register).map((field, idx) => {
     const scalaBundleField = getScalaBundleRegFieldName(field, idx);
-    return generateRegisterField(field, `${scalaRegBundleName}.${scalaBundleField}`, field.access || access);
+    return `${field.bitOffset} -> ` + generateRegisterField(field, `${scalaRegBundleName}.${scalaBundleField}`, field.access || access);
   });
 
   const registerDesc = register.description ? `Some("${register.description}")` : 'None';
 
   return endent`
-    ${register.addressOffset} -> RegFieldGroup("${register.name}", ${registerDesc}, Seq(
+    ${register.addressOffset} -> RegFieldGroup("${register.name}", ${registerDesc}, padFields(
       ${regFieldSeqElements.join(',\n')}))`;
 };
 
@@ -145,7 +167,7 @@ const generateRegisterReset = (access, register, addressBlockNames) => {
     const scalaBundleField = getScalaBundleRegFieldName(field, idx);
     const resetValue = `${resetBundleName}.${scalaBundleField}`;
     const resetWire = `${scalaRegBundleName}.${scalaBundleField}`;
-    return access ? `${resetWire} := ${resetValue}` : `RegField(${field.bits})`;
+    return access ? `${resetWire} := ${resetValue}` : `RegField(${field.bitWidth})`;
   });
 
   return regFieldSeqElements.join('\n');
@@ -170,12 +192,19 @@ const getAddressBlockNames = addressBlock => {
     ioBundle: `${addressBlock.name}AddressBlockBundle`,
     regMapRegister: 'register',
     regMapResetWire: 'resetValue',
+    paramsName: 'componentParams',
     tlRegMap: `${addressBlock.name}TLRegMap`,
     axi4RegMap: `${addressBlock.name}AXI4RegMap`
   };
 };
 
-const generateBodyBase = (names, addressBlock, deviceNameString, compatString) => {
+const generateBodyBase = ({
+  names,
+  addressBlock,
+  deviceNameString,
+  compatString,
+  blackboxParams
+}) => {
   const registerMapElements = addressBlock.registers.map((register) => {
     return generateRegister(register.access || addressBlock.access, register, names);
   });
@@ -188,7 +217,7 @@ const generateBodyBase = (names, addressBlock, deviceNameString, compatString) =
     return generateRegisterResetBaseParams(register);
   });
 
-  const bundleDefs = generateAddressBlockBundles(addressBlock);
+  const bundleDefs = generateAddressBlockBundles(addressBlock, blackboxParams);
   const baseParamsObject = endent`
     object ${names.baseParamsObject.name} {
       def ${names.baseParamsObject.deviceTreeName}: String = ${deviceNameString}
@@ -199,52 +228,88 @@ const generateBodyBase = (names, addressBlock, deviceNameString, compatString) =
       }
     }
   `;
+
+  const blackboxParamAliases = blackboxParams.fields.map(field => {
+    return `val ${field.name} = ${names.paramsName}.${field.name}`;
+  });
+
   const registerRouter = endent`
-    abstract class ${names.regRouter}(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
+    abstract class ${names.regRouter}(
+      busWidthBytes: Int,
+      baseAddress: Long,
+      ${names.paramsName}: ${blackboxParams.className})(implicit p: Parameters)
       extends IORegisterRouter(
         RegisterRouterParams(
           name = ${names.userParamsObject.name}.${names.userParamsObject.deviceTreeName},
           compat = ${names.userParamsObject.name}.${names.userParamsObject.deviceTreeCompat},
           base = baseAddress,
           beatBytes = busWidthBytes),
-        new ${names.ioBundle}) {
+        new ${names.ioBundle}(${names.paramsName})) {
+
+      private def padFields(fields: (Int, RegField)*) = {
+        var previousOffset = 0
+        var previousField: Option[RegField] = None
+
+        fields.flatMap { case (fieldOffset, field) =>
+          val padWidth = fieldOffset - previousOffset
+          require(padWidth >= 0,
+            previousField.map(f => s"register fields at $previousOffset and $fieldOffset are overlapping")
+              .getOrElse(s"register field $field has a negative offset"))
+
+          previousOffset = fieldOffset
+          previousField = Some(field)
+
+          if (padWidth > 0) {
+            Seq(RegField(padWidth), field)
+          } else {
+            Seq(field)
+          }
+        }
+      }
 
       lazy val module = new LazyModuleImp(this) {
         val portValue = ioNode.makeIO()
         val ${names.regMapResetWire} = Wire(portValue.cloneType.asOutput)
-    ${indent(4)(resetElements.join('\n'))}
+        ${resetElements.join('\n')}
 
         val ${names.regMapRegister} = RegInit(resetValue)
         portValue <> ${names.regMapRegister}
 
-        val mapping = Seq(
-    ${indent(6)(registerMapElements.join(',\n'))})
+        val mapping = {
+          ${blackboxParamAliases.join('\n')}
+          Seq(
+            ${registerMapElements.join(',\n')})
+        }
+
         regmap(mapping:_*)
       }
     }
   `;
 
   const tlRegisterRouter = endent`
-    class ${names.tlRegMap}(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
-      extends ${names.regRouter}(busWidthBytes, baseAddress) with HasTLControlRegMap
-  `;
+    class ${names.tlRegMap}(busWidthBytes: Int, baseAddress: Long, ${names.paramsName}: ${blackboxParams.className})(implicit p: Parameters)
+      extends ${names.regRouter}(busWidthBytes, baseAddress, ${names.paramsName}) with HasTLControlRegMap`;
 
   const axi4RegisterRouter = endent`
-    class ${names.axi4RegMap}AXI4RegMap(busWidthBytes: Int, baseAddress: Long)(implicit p: Parameters)
-      extends ${names.regRouter}(busWidthBytes, baseAddress) with HasAXI4ControlRegMap
-  `;
+    class ${names.axi4RegMap}AXI4RegMap(busWidthBytes: Int, baseAddress: Long, ${names.paramsName}: ${blackboxParams.className})(implicit p: Parameters)
+      extends ${names.regRouter}(busWidthBytes, baseAddress, ${names.paramsName}) with HasAXI4ControlRegMap`;
 
   return {
-    imports: {
-      chisel3: '_',
-      'freechips.rocketchip': [
-        'amba.axi4.HasAXI4ControlRegMap',
-        'config.Parameters',
-        'diplomacy.LazyModuleImp',
-        'regmapper._',
-        'tilelink.HasTLControlRegMap'
-      ]
-    },
+    imports: [
+      'chisel3._',
+      '',
+      {
+        'freechips.rocketchip': [
+          'amba.axi4.HasAXI4ControlRegMap',
+          'config.Parameters',
+          'diplomacy.LazyModuleImp',
+          'regmapper._',
+          'tilelink.HasTLControlRegMap'
+        ]
+      },
+      '',
+      blackboxParams.packageName + '.' + blackboxParams.className
+    ],
     blocks: bundleDefs.concat([
       baseParamsObject,
       registerRouter,
@@ -273,12 +338,51 @@ const generateBodyUser = (names, addressBlock) => {
   };
 };
 
+const generateBlackBoxComponents = component => {
+  const paramFields = [];
+
+  // TODO only integer params supported
+  paramSchema.reduce({
+    leaf: (node, path) => {
+      const name = path.join('_');
+      const paramField = {
+        name: name,
+        type: 'Int'
+      };
+      if (node.default) {
+        paramField['defaultValue'] = node.default;
+      }
+      paramFields.push(paramField);
+    }
+  })(component.pSchema);
+
+  const blackboxParams = {
+    className: `${component.name}Params`,
+    fields: paramFields
+  };
+
+  return {
+    imports: ['chisel3._'],
+    blocks: [chisel.generateCaseClass(blackboxParams)],
+    blackboxParams: blackboxParams
+  };
+};
+
 const exportRegmap = comp => {
   const memoryMaps = comp.memoryMaps || [];
+  const packageNameBase = `${comp.vendor}.${comp.library}.${comp.name}.regmap`;
+  const blackboxParams = generateBlackBoxComponents(comp);
+  blackboxParams.blackboxParams.packageName = packageNameBase;
 
   let baseResult = {};
+  baseResult[`${comp.name}Params`] = endent`
+    package ${packageNameBase}
+
+    ${chisel.serializeImports(blackboxParams.imports)}
+
+    ${blackboxParams.blocks.join('\n\n')}
+  `;
   let userResult = {};
-  const packageNameBase = `package ${comp.vendor}.${comp.library}.${comp.name}`;
   memoryMaps.forEach((memoryMap) => {
     const addressBlocks = memoryMap.addressBlocks;
 
@@ -290,7 +394,13 @@ const exportRegmap = comp => {
       const deviceNameString = `"${comp.name}-${addressBlock.name}"`;
       const names = getAddressBlockNames(addressBlock);
 
-      const base = generateBodyBase(names, addressBlock, deviceNameString, compatString);
+      const base = generateBodyBase({
+        names: names,
+        addressBlock: addressBlock,
+        deviceNameString: deviceNameString,
+        compatString: compatString,
+        blackboxParams: blackboxParams.blackboxParams
+      });
       const user = generateBodyUser(names, addressBlock);
 
       memoryMapBaseResult[`${addressBlock.name}-base`] = endent`

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -205,8 +205,11 @@ const padFieldsMethod = endent`
     fields.flatMap { case (fieldOffset, field) =>
       val padWidth = fieldOffset - previousOffset
       require(padWidth >= 0,
-        previousField.map(f => s"register fields at $previousOffset and $fieldOffset are overlapping")
-          .getOrElse(s"register field $field has a negative offset"))
+        if (previousField.isDefined) {
+          s"register fields at $previousOffset and $fieldOffset are overlapping"
+        } else {
+          s"register field $field has a negative offset"
+        })
 
       previousOffset = fieldOffset
       previousField = Some(field)


### PR DESCRIPTION
adds a `componentParams` argument to exported `RegisterRouter`s for parameters in the DUH document. Also updates emitted register maps to use the new `bitOffset` and `bitWidth` fields which can be parameterized. user code is unchanged

generated regmap for pio.json5
```scala
// Generated Code
// Please DO NOT EDIT
package sifive.blocks.pio.regmap.CSR.csrAddressBlock

import chisel3._

import freechips.rocketchip.amba.axi4.HasAXI4ControlRegMap
import freechips.rocketchip.config.Parameters
import freechips.rocketchip.diplomacy.LazyModuleImp
import freechips.rocketchip.regmapper._
import freechips.rocketchip.tilelink.HasTLControlRegMap

import sifive.blocks.pio.regmap.pioParams

class ODATARegisterBundle(
  val dataWidth: Int
) extends Bundle {
  val data = Output(UInt(dataWidth.W))
}

class OENABLERegisterBundle(
  val dataWidth: Int
) extends Bundle {
  val data = Output(UInt(dataWidth.W))
}

class IDATARegisterBundle(
  val dataWidth: Int
) extends Bundle {
  val data = Input(UInt(dataWidth.W))
}

class csrAddressBlockAddressBlockBundle(val params: pioParams) extends Bundle {
  val ODATA = new ODATARegisterBundle(
    dataWidth = params.dataWidth
  )
  val OENABLE = new OENABLERegisterBundle(
    dataWidth = params.dataWidth
  )
  val IDATA = new IDATARegisterBundle(
    dataWidth = params.dataWidth
  )
}

object csrAddressBlockRegRouterBase {
  def deviceTreeName: String = "pio-csrAddressBlock"
  def deviceTreeCompat: Seq[String] = Seq("sifive,pio-0.1.0")

  object resetValues {
    object ODATA {
      def data: UInt = 0.U
    }

    object OENABLE {
      def data: UInt = 0.U
    }

    object IDATA {
      def data: UInt = 0.U
    }
  }
}

abstract class csrAddressBlockRegRouter(
  busWidthBytes: Int,
  baseAddress: Long,
  componentParams: pioParams)(implicit p: Parameters)
  extends IORegisterRouter(
    RegisterRouterParams(
      name = csrAddressBlockRegRouterUser.deviceTreeName,
      compat = csrAddressBlockRegRouterUser.deviceTreeCompat,
      base = baseAddress,
      beatBytes = busWidthBytes),
    new csrAddressBlockAddressBlockBundle(componentParams)) {

  private def padFields(fields: (Int, RegField)*) = {
    var previousOffset = 0
    var previousField: Option[RegField] = None

    fields.flatMap { case (fieldOffset, field) =>
      val padWidth = fieldOffset - previousOffset
      require(padWidth >= 0,
        previousField.map(f => s"register fields at $previousOffset and $fieldOffset are overlapping")
          .getOrElse(s"register field $field has a negative offset"))

      previousOffset = fieldOffset
      previousField = Some(field)

      if (padWidth > 0) {
        Seq(RegField(padWidth), field)
      } else {
        Seq(field)
      }
    }
  }

  lazy val module = new LazyModuleImp(this) {
    val portValue = ioNode.makeIO()
    val resetValue = Wire(portValue.cloneType.asOutput)
    resetValue.ODATA.data := csrAddressBlockRegRouterUser.resetValues.ODATA.data
    resetValue.OENABLE.data := csrAddressBlockRegRouterUser.resetValues.OENABLE.data
    resetValue.IDATA.data := csrAddressBlockRegRouterUser.resetValues.IDATA.data

    val register = RegInit(resetValue)
    portValue <> register

    val mapping = {
      val dataWidth = componentParams.dataWidth
      Seq(
        0 -> RegFieldGroup("ODATA", None, padFields(
          0 -> RegField(dataWidth, resetValue.ODATA.data, RegFieldDesc("data", "")))),
        4 -> RegFieldGroup("OENABLE", Some("determines whether the pin is an input or an output. If the data direction bit is a 1, then the pin is an input"), padFields(
          0 -> RegField(dataWidth, resetValue.OENABLE.data, RegFieldDesc("data", "")))),
        8 -> RegFieldGroup("IDATA", Some("read the port pins"), padFields(
          0 -> RegField.r(dataWidth, resetValue.IDATA.data, RegFieldDesc("data", "")))))
    }

    regmap(mapping:_*)
  }
}

class csrAddressBlockTLRegMap(busWidthBytes: Int, baseAddress: Long, componentParams: pioParams)(implicit p: Parameters)
  extends csrAddressBlockRegRouter(busWidthBytes, baseAddress, componentParams) with HasTLControlRegMap

class csrAddressBlockAXI4RegMapAXI4RegMap(busWidthBytes: Int, baseAddress: Long, componentParams: pioParams)(implicit p: Parameters)
  extends csrAddressBlockRegRouter(busWidthBytes, baseAddress, componentParams) with HasAXI4ControlRegMap
```