### PR TITLE
use def instead of val for desiredName override

### DIFF
--- a/lib/chisel-utils.js
+++ b/lib/chisel-utils.js
@@ -132,7 +132,7 @@ const generateBlackBox = ({
         ${stringIOParams.join(',\n')}
       ))
 
-      override val desiredName = "${desiredName}"
+      override def desiredName = "${desiredName}"
     }
   `;
   return stringValue;


### PR DESCRIPTION
using `val` results in `scala.UninitializedFieldError: Uninitialized field` for some reason