### PR TITLE
Set resetValue in OMRegFieldDesc if present.

### DIFF
--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -4,6 +4,9 @@ const chisel = require('./chisel-utils.js');
 const endent = require('endent');
 const paramSchema = require('./param-schema.js');
 
+// Check whether value is defined, counting 0 as truthy.
+const isDefinedNumber = i => !!(i || i === 0);
+
 //// GNERATE BUNDLES ////
 
 const getScalaBundleRegFieldName = (field, idx) => {
@@ -81,7 +84,7 @@ const generateAddressBlockBundles = (addressBlock, blackboxParams) => {
 
 //// GNERATE REGROUTER ////
 
-const generateRegisterField = (field, scalaRegisterName, access) => {
+const generateRegisterField = (field, scalaRegisterName, access, resetValue) => {
   if (access) {
     var result = '';
     switch (access) {
@@ -100,8 +103,9 @@ const generateRegisterField = (field, scalaRegisterName, access) => {
       throw new Error(`invalid access field value: ${access}`);
     }
     result += `(${field.bitWidth}, ${scalaRegisterName}`;
-    if (field.name || field.desc) {
-      result += `, RegFieldDesc("${field.name || ''}", "${field.desc || ''}")`;
+    if (field.name || field.desc || isDefinedNumber(resetValue)) {
+      const resetValueString = isDefinedNumber(resetValue) ? `, reset = Some(${resetValue})`: '';
+      result += `, RegFieldDesc("${field.name || ''}", "${field.desc || ''}"${resetValueString})`;
     }
     result += ')';
     return result;
@@ -450,7 +454,7 @@ const generateOMRegisterMap = (addressUnitBits, addressBlock) => {
   const registerMapElements = addressBlock.registers.map((register) => {
     const regFieldSeqElements = (register.fields || []).map(field => {
       const access = field.access || register.access || addressBlock.access;
-      return `${field.bitOffset} -> ` + generateRegisterField(field, 'Bool()', access);
+      return `${field.bitOffset} -> ` + generateRegisterField(field, 'Bool()', access, field.resetValue);
     });
 
     const registerDesc = register.description ? `Some("${register.description}")` : 'None';


### PR DESCRIPTION
This propagates the resetValue information on register fields to the Object Model, since previously it was incorrectly getting set to None/undefined.

Note that this only affects `duh-export-scala` and not `duh-export-regmap`, since I wasn't sure of the best way of updating the regmap exporter, given that the reset values are set via a Scala `object` rather than in the `RegFieldDesc` itself.