### PR TITLE
enable exclusion of bus fields that are not defined in rocket-chip

### DIFF
--- a/lib/axi4-tl.js
+++ b/lib/axi4-tl.js
@@ -162,6 +162,20 @@ const masterAttachGen = comp => e =>
 const slaveAttachGen = comp => e =>
   `bap.pbus.coupleTo("axi") { ${comp.name}_top.get${e.name}NodeTLAdapter() := TLWidthWidget(bap.pbus) := _ }`;
 
+// fields defined in bus spec but not in scala bundle, values are tie-off values
+const excludes = {
+  aw: {
+    bits: {
+      region: 0
+    }
+  },
+  ar: {
+    bits: {
+      region: 0
+    }
+  }
+};
+
 const busDef = {
   aw: {
     valid: 1,
@@ -175,8 +189,8 @@ const busDef = {
       lock: 1,
       cache: 4,
       prot: 3,
-      qos: 4
-      // region: 4
+      qos: 4,
+      region: 4
     }
   },
   w: {
@@ -210,8 +224,8 @@ const busDef = {
       lock: 1,
       cache: 4,
       prot: 3,
-      qos: 4
-      // region: 4
+      qos: 4,
+      region: 4
       // user: 'arUserWidth' // not in IP-XACT
     }
   },
@@ -255,5 +269,6 @@ module.exports = {
     imports: [
       'freechips.rocketchip.amba.axi4.{AXI4Bundle, AXI4EdgeParameters, AXI4MonitorArgs, AXI4MonitorBase}'
     ]
-  }
+  },
+  excludes: excludes
 };

--- a/lib/export-scala-base.js
+++ b/lib/export-scala-base.js
@@ -39,18 +39,18 @@ const buses = {
     //   AHBLite: ahblite.busDef
     // },
     AMBA4: {
-      AXI4: axi4Tl.busDef,
-      'AXI4-Lite': axi4Tl.busDef,
-      APB4: apb.busDef
+      AXI4: axi4Tl,
+      'AXI4-Lite': axi4Tl,
+      APB4: apb
     }
   },
   'sifive.com': {
     MEM: {
-      SPRAM: spram.busDef,
-      DPRAM: dpram.busDef
+      SPRAM: spram,
+      DPRAM: dpram
     },
     basic: {
-      channel: exportScalaChannel.busDef
+      channel: exportScalaChannel
     }
   }
 };
@@ -111,13 +111,15 @@ const perBusInterfaceWiring = comp => {
 
     let res = '// wiring for ' + e.name + ' of type ' + e.busType.name + '\n';
 
-    const bus = get(
+    const generator = get(
       buses,
       [e.busType.vendor, e.busType.library, e.busType.name]
     );
-    if (bus === undefined) {
+    if (generator === undefined) {
       return res + '// ' + JSON.stringify(lPortMap) + '\n';
     }
+    const bus = generator.busDef;
+    const excludes = generator.excludes;
 
     res += '// -> ' + JSON.stringify(bus) + '\n';
 
@@ -146,6 +148,15 @@ const perBusInterfaceWiring = comp => {
         const tlName = path.join('.');
         const sig = signValue(node);
         const isInputBusPort = sig.sign ^ (e.interfaceMode == 'slave');
+
+        const exclude = get(excludes || {}, path);
+        if (exclude !== undefined && lPortMap[busName]) {
+          const blackboxPort = lPortMap[busName]; // .physicalPort.name;
+          if (!isInputBusPort) {
+            res += blackWire['in'](`${exclude}.U`, blackboxPort) + '\n';
+          }
+          return;
+        }
 
         if (lPortMap[busName]) {
           const busPort = e.name + '0.' + tlName;


### PR DESCRIPTION
the `arregion` and `awregion` fields are not defined the rocket-chip `AXI4Bundle`. This changes fixes a bug where the emitted scala code expected to find those `region` fields.