### PR TITLE
Fix APB port directions

### DIFF
--- a/lib/apb-scala.js
+++ b/lib/apb-scala.js
@@ -68,12 +68,12 @@ const masterNodeGen = () => e => `val ${e.name}Node: TLOutwardNode = (
 `;
 
 const busDef = {
-  prdata: 'dataWidth',
+  prdata: '-dataWidth',
   pwrite: 1,
   penable: 1,
   psel: 1,
   pready: -1,
-  pslverr: 1,
+  pslverr: -1,
   paddr: 'addrWidth',
   pwdata: 'dataWidth',
   pprot: 3


### PR DESCRIPTION
This PR makes ~~two~~ one change~~s~~:

- ~~https://github.com/sifive/duh-scala/commit/f6e1aca2113d98fa6b505488718c99e7f30b7ad1 - This adds a bit of logic to check that the actual component port direction matches the corresponding bus definition, throwing an exception if it doesn't match.~~
- https://github.com/sifive/duh-scala/pull/59/commits/a07bccfb8c078c94048d2f11c063fcae98b6db50 - This actually corrects the APB bus definition, where two of the ports (`prdata `, `pslverr`) are flipped.

As a side note, we should probably take a pass at double checking that all of the bus definitions here match the `duh-bus` ones.