### PR TITLE
Error out if blackbox port doesn't match bus definition.

### DIFF
--- a/lib/export-scala-base.js
+++ b/lib/export-scala-base.js
@@ -162,6 +162,10 @@ const perBusInterfaceWiring = comp => {
           const busPort = e.name + '0.' + tlName;
           const blackboxPort = lPortMap[busName]; // .physicalPort.name;
           const direction = isInputBusPort ? 'out' : 'in';
+          const blackboxPortDirection = portObj[blackboxPort].wire.direction;
+          if (direction !== blackboxPortDirection) {
+            throw new Error(`Verilog port ${blackboxPort} and ${e.busType.name} bus port ${busName} direction mismatch: ${blackboxPortDirection} != ${direction}`);
+          }
           res += blackWire[direction](busPort, blackboxPort) + '\n';
           return;
         }


### PR DESCRIPTION
Pulled out this commit from https://github.com/sifive/duh-scala/pull/59.

This adds a bit of logic to check that the actual component port direction matches the corresponding bus definition, throwing an exception if it doesn't match.

@albertchen-sifive made the following comment about this change in the previous PR:

> might be wrong about what this is doing, but input bus interface signals should be able to be mapped to both input and output blackbox ports since they can be driven by either? I think we only want to do this check if the bus interface port is an output?


I'm not understanding why the input signals are any different than the output signals. Could you explain why a bus interface input signal can be mapped to either an input or an output blackbox port?