### PR TITLE
make dpram/spram chisel attch code overrideable

### DIFF
--- a/lib/dpram.js
+++ b/lib/dpram.js
@@ -39,8 +39,7 @@ exports.master = {
 val ${e.name}Node = BundleBridgeSink[${e.name}Bundle]
 ${e.name}Node := imp.${e.name}Node
 
-InModuleBody {
-  val ${e.name}0 = ${e.name}Node.bundle
+def ${e.name}NodeChiselAttach(${e.name}0: ${e.name}Bundle): Unit = {
   val ${e.name}Mem = SyncReadMem(${addrSpace}, Vec(${banks}, UInt((${dataBankWidth}).W)))
 
   val writeAddress = ${io.WRADDR}
@@ -63,6 +62,8 @@ ${indent(4)(writePort)}
     indent(2)(writePort)
 }
 }
+
+InModuleBody(${e.name}NodeChiselAttach(${e.name}Node.bundle))
 `;
   }
 };

--- a/lib/spram.js
+++ b/lib/spram.js
@@ -39,7 +39,7 @@ exports.master = {
 val ${e.name}Node = BundleBridgeSink[${e.name}Bundle]
 ${e.name}Node := imp.${e.name}Node
 
-InModuleBody {
+def ${e.name}NodeChiselAttach(${e.name}0: ${e.name}Bundle): Unit = {
   val ${e.name}0 = ${e.name}Node.bundle
   val ${e.name}Mem = SyncReadMem(${addrSpace}, Vec(${banks}, UInt((${dataBankWidth}).W)))
 
@@ -55,6 +55,8 @@ ${indent(4)(readWritePort)}
     indent(2)(readWritePort)
 }
 }
+
+InModuleBody(${e.name}NodeChiselAttach(${e.name}Node.bundle))
 `;
   }
 };


### PR DESCRIPTION
The current way the dpram/spram code is generated makes it impossible to override the chisel code that instantiates a memory and attaches it to the ports. This PR moves that chisel code into a method that can be overrided in the user code.

So, say you wanted to mux in some other signals into your mem port, you could override the generated method in the `N*Top` class like so:
```
val select = BundleBridgeSink(() => Bool())
val externalMemPort = BundleBridgeSource(() => new MEMBundle())
override def MEMNodeChiselAttach(impMemPort: MEMBundle): Unit = {
  super.MEMNodeChiselAttach(Mux(select.bundle, externalMemPort.bundle, impMemPort))
}
```