### PR TITLE
Don't overpad fields by accounting for width.

### DIFF
--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -231,7 +231,7 @@ const padFieldsMethod = endent`
     var previousField: Option[RegField] = None
 
     fields.flatMap { case (fieldOffset, field) =>
-      val padWidth = fieldOffset - previousOffset
+      val padWidth = fieldOffset - (previousOffset + previousField.map(_.width).getOrElse(0))
       require(padWidth >= 0,
         if (previousField.isDefined) {
           s"register fields at $previousOffset and $fieldOffset are overlapping"


### PR DESCRIPTION
There was a bug in the existing implementation of the `padFields()` method. Previously, if you had call that looked like the following:

```scala
padFields(
  0 -> RegField(2, Bool(), RegFieldDesc("foo", ""),
  2 -> RegField(4, Bool(), RegFieldDesc("bar", ""),
)
```

It would result in the following actual bitfield packing:

```
[1:0] foo
[3:2] reserved
[7:4] bar
```

The issue is that the algorithm for determining the padding needed didn't account for the _width_ of the previous field, and instead measured pad width from the initial offset of the previous field. Note that this only ever affected the Object Model, which currently will have incorrect offsets for any field besides the first one in a register field group (a.k.a. a register).

This PR adds in the width of the previous field when determining the pad width.

This was tested on an example similar to the above, and I confirmed that the equivalent of `bar` appeared at the correct bit offset.