### PR TITLE
Replace .asOutput with Output() for chisel3 forwards compatibility.

### DIFF
--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -310,7 +310,7 @@ const generateBodyBase = ({
       ${padFieldsMethod}
 
       lazy val module = new LazyModuleImp(this) {
-        val ${names.regMapResetWire} = Wire(port.cloneType.asOutput)
+        val ${names.regMapResetWire} = Wire(Output(port.cloneType))
         ${resetElements.join('\n')}
 
         val ${names.regMapRegister} = RegInit(resetValue)


### PR DESCRIPTION
I'm not sure how this ever worked in the past, but because we don't do the `import Chisel._` compatibility layer import in the generated file, the legacy, implicit `.asOutput` method isn't defined and it causes a compile-time error. This would only affect designs where one invokes `duh-export-regmap`, since that code is only generated there.

I'm not exactly sure I understand the proper Chisel 3 replacement, but this change seemed to compile for me.