### PR TITLE
Allow for newline characters in register description.

### DIFF
--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -481,7 +481,7 @@ const generateOMRegisterMap = (addressUnitBits, addressBlock) => {
       return `${field.bitOffset} -> ` + generateRegisterField(field, 'Bool()', access, field.resetValue);
     });
 
-    const registerDesc = register.description ? `Some("${register.description}")` : 'None';
+    const registerDesc = register.description ? `Some("""${register.description}""")` : 'None';
 
     if (addressUnitBits % 8 != 0) {
       throw new Error('addressUnitBits must be a multiple of 8.');


### PR DESCRIPTION
Fixes #68.

This PR makes the really easy fix of using triple double quotes to allow for newlines in the register description.

I tried exploring a different solution where we properly escape special characters so that the emitted Scala code will always be safe for string literals, but it turns out that the endent library has a minor bug where escaped control characters end up getting double interpreted. Someone fortunately opened a [PR](https://github.com/indentjs/endent/pull/6) against endent to fix it, but based on the relatively low usage of that library, I'm not sure how soon it'll get merged in.