### PR TITLE
Handle unsorted register fields

### DIFF
--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -226,21 +226,29 @@ const getAddressBlockNames = addressBlock => {
 };
 
 const padFieldsMethod = endent`
+  private def prettyPrintField(field: RegField, bitOffset: Int): String = {
+    val nameOpt = field.desc.map(_.name)
+    nameOpt.map(_ + " ").getOrElse("") + s"at offset $bitOffset"
+  }
   private def padFields(fields: (Int, RegField)*) = {
     var previousOffset = 0
-    var previousField: Option[RegField] = None
+    var previousFieldOpt: Option[RegField] = None
 
     fields.flatMap { case (fieldOffset, field) =>
-      val padWidth = fieldOffset - (previousOffset + previousField.map(_.width).getOrElse(0))
-      require(padWidth >= 0,
-        if (previousField.isDefined) {
-          s"register fields at $previousOffset and $fieldOffset are overlapping"
-        } else {
-          s"register field $field has a negative offset"
-        })
+      val padWidth = fieldOffset - (previousOffset + previousFieldOpt.map(_.width).getOrElse(0))
+      val prettyField = prettyPrintField(field, fieldOffset)
+      require(
+        padWidth >= 0,
+        previousFieldOpt.map(previousField => {
+          val prettyPrevField = prettyPrintField(previousField, previousOffset)
+          s"register fields $prettyPrevField and $prettyField are overlapping"
+        }).getOrElse(
+          s"register field $prettyField has a negative offset"
+        )
+      )
 
       previousOffset = fieldOffset
-      previousField = Some(field)
+      previousFieldOpt = Some(field)
 
       if (padWidth > 0) {
         Seq(RegField(padWidth), field)

--- a/lib/export-scala-regmap.js
+++ b/lib/export-scala-regmap.js
@@ -234,7 +234,7 @@ const padFieldsMethod = endent`
     var previousOffset = 0
     var previousFieldOpt: Option[RegField] = None
 
-    fields.flatMap { case (fieldOffset, field) =>
+    fields.sortBy({ case (offset, _) => offset }).flatMap { case (fieldOffset, field) =>
       val padWidth = fieldOffset - (previousOffset + previousFieldOpt.map(_.width).getOrElse(0))
       val prettyField = prettyPrintField(field, fieldOffset)
       require(


### PR DESCRIPTION
The object model regmap generation currently fails if the list of register fields in the DUH document is unsorted. This PR is 90% me making the error message nicer to read, and 10% actually sorting the fields before attempting to compute the offset padding.

- https://github.com/sifive/duh-scala/commit/e9c53cc58ac7c69a757244b49e28ccbdb3da2b91 makes the error message print out the actual name of the register field
- https://github.com/sifive/duh-scala/commit/a3a4ffe9e5b948cd508ff5dab754baca84978622 sorts the list of fields before doing the offset and padding computation

Tested this on a document that had its register fields defined in an unsorted order and confirmed that this fixed the run.