### PR TITLE
Properly set the resources on the APBSlaveParameters.

### DIFF
--- a/lib/apb-scala.js
+++ b/lib/apb-scala.js
@@ -17,7 +17,7 @@ const slaveAdapterGen = comp => e => {
     APBSlavePortParameters(
       slaves = Seq(APBSlaveParameters(
         address = List(AddressSet(${params}.base, ((1L << ${addrWidth}) - 1))),
-        // resources
+        resources = device.reg,
         // regionType
         executable = false,
         // nodePath


### PR DESCRIPTION
Fixes #76.

Without setting this, the resources (e.g. memory map information) generated from Diplomacy have no way of attaching to the Diplomacy Device object, which consequently means that neither the Object Model will not be able to serialize the memory map information being onboarded.

In this code snippet, the `device` variable is in scope due to it being defined elsewhere.

Tested this on an IP block that happens to have an APB slave interface.