### PR TITLE
fix to emit correct INTERRUPT code

### DIFF
--- a/lib/export-scala-base.js
+++ b/lib/export-scala-base.js
@@ -30,7 +30,7 @@ const generators = {
   APB: apb,
   APB4: apb,
   // AHBLite: ahblite,
-  interrupts: intcTl,
+  INTERRUPT: intcTl,
   channel: exportScalaChannel
 };
 


### PR DESCRIPTION
Emit correct scala code for sifive.com/PRCI/INTERRUPT/0.1.0 busDef:

https://github.com/sifive/duh-bus/blob/master/specs/sifive.com/PRCI/INTERRUPT/0.1.0/INTERRUPT_rtl.json5

Test code: https://github.com/sifive/block-pio-sifive/pull/71

examples:

```js
        portMaps: {

          IRQ: [                // SW: PLIC.PIO0.mask
            'irq0',             // SW: PLIC.PIO0.irq0.mask
            'irq1'              // SW: PLIC.PIO0.irq1.mask
          ],

          IRQ: [                // SW: PLIC.PIO0.mask
            'irq[0]',           // SW: PLIC.PIO0.irq_0.mask
            'irq[1]'            // SW: PLIC.PIO0.irq_1.mask
          ],

          IRQ: 'irq',           // SW: PLIC.PIO0.mask - 2bit filed

          IRQ: {                // SW: PLIC.PIO0.mask
            tx: 'irq0',         // SW: PLIC.PIO0.tx.mask
            rx: 'irq1'          // SW: PLIC.PIO0.rx.mask
          },

          IRQ: {                // SW: PLIC.PIO0.mask
            tx: 'irq[0]',       // SW: PLIC.PIO0.tx.mask
            rx: 'irq[1]'        // SW: PLIC.PIO0.rx.mask
          },

          IRQ: {                // SW: PLIC.PIO0.mask
            tx: 'irq[0]',       // SW: PLIC.PIO0.tx.mask
                                // SW: PLIC.PIO0.rx.mask ???
            rx_full: 'irq[1]',  // SW: PLIC.PIO0.rx_full.mask
            rx_empty: 'irq[2]'  // SW: PLIC.PIO0.rx_empty.mask
          },

          IRQ: {                // SW: PLIC.PIO0.mask
            tx: ['irq[0]'],     // SW: PLIC.PIO0.tx.mask
            rx: {               // SW: PLIC.PIO0.rx.mask
              full: 'irq[1]',   // SW: PLIC.PIO0.rx.full.mask
              empty: 'irq[2]'   // SW: PLIC.PIO0.rx.empty.mask
            }
          },


        }

```